### PR TITLE
Migrate to sbt-ci-release with automatic maven publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "master" ]
+    tags: ["v*"]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -20,10 +29,24 @@ jobs:
 
       - uses: coursier/cache-action@v6
 
-      - name: scala
-        uses: olafurpg/setup-scala@v11
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'sbt'
+
+      - name: Cache sbt
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: build ${{ matrix.scala }}
         run: sbt ++${{ matrix.scala }} clean coverage test
@@ -42,3 +65,38 @@ jobs:
           type: ${{ job.status }}
           job_name: Build
           url: ${{ secrets.SLACK_WEBHOOK }}
+
+  publish:
+    name: Publish Artifacts
+    needs: [ build ]
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: 'sbt'
+
+      - name: Cache sbt
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Publish artifacts
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASS }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,6 @@ scalaVersion := crossScalaVersions.value.head
 
 crossScalaVersions := Seq("2.13.8", /*"3.2.0", */"2.12.17")
 
-publishTo := Some(Resolver.evolutionReleases)
-
 libraryDependencies ++= crossSettings(
   scalaVersion.value,
   if3 = Nil,
@@ -49,4 +47,19 @@ libraryDependencies ++= Seq(
 
 licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 
-releaseCrossBuild := true
+description             := "Cache in Scala with cats-effect"
+
+sonatypeCredentialHost := "s01.oss.sonatype.org"
+
+sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
+
+Test / publishArtifact  := false
+
+scmInfo                 := Some(
+  ScmInfo(
+    url("https://github.com/evolution-gaming/scache"),
+    "git@github.com:evolution-gaming/scache.git",
+  ),
+)
+
+enablePlugins(GitVersioning)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.4")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.2")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "4.3.2-SNAPSHOT"


### PR DESCRIPTION
Probably fixes #163 
Hoping the current user has the ability to publish to the "com.evolutiongaming" sonatype org, this should enable automatic publishing artifacts: 

- snapshot on each push to master
- release on tag publish in the form of "v1.2.3"