### PR TITLE
Add more scaladocs to the project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,8 @@ libraryDependencies ++= Seq(
   scalatest % Test
 )
 
+autoAPIMappings := true
+
 licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 
 description             := "Cache in Scala with cats-effect"

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -708,6 +708,23 @@ object Cache {
 
     def withFence(implicit F: Concurrent[F]): Resource[F, Cache[F, K, V]] = CacheFenced.of(self)
 
+    /** Gets a value for specific key or uses another value.
+      *
+      * The semantics is exactly the same as in [[Cache#get]].
+      *
+      * Warning: The value passed as a second argument may only be returned, and
+      * never put into cache. If putting a value into cache is required, then
+      * [[Cache#getOrUpdate]] should be called instead.
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to get the missing value with.
+      *
+      * @return
+      *   The same semantics applies as in [[Cache#getOrUpdate]], except that in
+      *   this method there is no possibility to get [[scala.None]].
+      */
     def getOrElse(key: K, value: => F[V])(implicit F: Monad[F]): F[V] = {
       self
         .get(key)
@@ -844,7 +861,7 @@ object Cache {
 
     /** Gets a value for specific key, or tries to load it.
       *
-      * The difference between this method and [[Cache#getOrUpdateResource]] is
+      * The difference between this method and [[#getOrUpdateResource]] is
       * that this one allows the loading function to fail finding the value,
       * i.e. return [[scala.None]].
       *

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -265,7 +265,8 @@ trait Cache[F[_], K, V] {
     *
     * @return
     *   All keys and values in the cache put into map. Loaded values are
-    *   returned as `Right(v)`, while loading ones are represented by `Left(F[V])`.
+    *   returned as `Right(v)`, while loading ones are represented by
+    *   `Left(F[V])`.
     */
   def values1: F[Map[K, Either[F[V], V]]]
 

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -409,6 +409,12 @@ object Cache {
     * {{{
     * Cache.loading[F, String, User]
     * }}}
+    *
+    * @return
+    *   A new instance of a cache wrapped into [[cats.effect.Resource]]. Note,
+    *   that [[#clear]] method will be called on underlying cache when resource
+    *   is released to make sure all resources stored in a cache are also
+    *   released.
     */
   def loading[F[_]: Concurrent: Parallel: Runtime, K, V]: Resource[F, Cache[F, K, V]] = {
     loading(none)
@@ -423,6 +429,12 @@ object Cache {
     * {{{
     * Cache.loading[F, String, User](partitions = 8)
     * }}}
+    *
+    * @return
+    *   A new instance of a cache wrapped into [[cats.effect.Resource]]. Note,
+    *   that [[#clear]] method will be called on underlying cache when resource
+    *   is released to make sure all resources stored in a cache are also
+    *   released.
     */
   def loading[F[_]: Concurrent: Parallel: Runtime, K, V](partitions: Int): Resource[F, Cache[F, K, V]] = {
     loading(partitions.some)
@@ -471,6 +483,12 @@ object Cache {
     *   Number of partitions to use, or [[scala.None]] in case number of
     *   partitions should be determined automatically using passed `Runtime`
     *   implementation.
+    *
+    * @return
+    *   A new instance of a cache wrapped into [[cats.effect.Resource]]. Note,
+    *   that [[#clear]] method will be called on underlying cache when resource
+    *   is released to make sure all resources stored in a cache are also
+    *   released.
     */
   def loading[F[_]: Concurrent: Parallel: Runtime, K, V](partitions: Option[Int] = None): Resource[F, Cache[F, K, V]] = {
 
@@ -529,6 +547,12 @@ object Cache {
     *   Number of partitions to use, or [[scala.None]] in case number of
     *   partitions should be determined automatically using passed `Runtime`
     *   implementation.
+    *
+    * @return
+    *   A new instance of a cache wrapped into [[cats.effect.Resource]]. Note,
+    *   that [[#clear]] method will be called on underlying cache when resource
+    *   is released to make sure all resources stored in a cache are also
+    *   released.
     */
   def expiring[F[_]: Temporal: Runtime: Parallel, K, V](
     config: ExpiringCache.Config[F, K, V],

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -144,6 +144,11 @@ trait Cache[F[_], K, V] {
     * implementations use exceptions to bypass the loading mechanism internally,
     * so the performance may suffer in this case.
     *
+    * @param key
+    *   The key to return the value for.
+    * @param value
+    *   The function to run to load the missing value with.
+    *
     * @return
     *   The same semantics applies as in [[#getOrUpdate]], except that the
     *   method may return [[scala.None]] in case `value` completes to
@@ -632,10 +637,31 @@ object Cache {
         }
     }
 
-    /**
-      * Does not run `value` concurrently for the same key
-      * release will be called upon key removal from the cache
-      * In case of none returned, value will be ignored by cache
+    /** Gets a value for specific key, or tries to load it.
+      *
+      * The difference between this method and [[#getOrUpdate1]] is that this
+      * one allows the loading function to fail finding the value, i.e. return
+      * [[scala.None]].
+      *
+      * Note, that this may not come for free in some implementations, i.e. some
+      * implementations use exceptions to bypass the loading mechanism
+      * internally, so the performance may suffer in this case.
+      *
+      * Also, this method is meant to be used where [[cats.effect.Resource]] is
+      * not convenient to use, i.e. when integration with legacy code is
+      * required or for internal implementation. For all other cases it is
+      * recommended to use [[#getOrUpdateResourceOpt]] instead as more
+      * human-readable alernative.
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @return
+      *   The same semantics applies as in [[#getOrUpdate1]], except that the
+      *   method may return [[scala.None]] in case `value` completes to
+      *   [[scala.None]].
       */
     def getOrUpdateOpt1[A](key: K)(
       value: => F[Option[(A, V, Option[Cache[F, K, V]#Release])]])(implicit

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -14,6 +14,11 @@ import scala.util.control.NoStackTrace
 
 /** Tagless Final implementation of a cache interface.
   *
+  * Most developers using the library may want to use [[Cache#expiring]] to
+  * construct the cache, though, if element expiration is not required, then
+  * it might be useful to use
+  * [[Cache#loading[F[_],K,V](partitions:Option[Int])*]] instead.
+  *
   * @tparam F
   *   Effect to be used in effectful methods such as [[#get]].
   * @tparam K
@@ -162,6 +167,11 @@ object Cache {
     *
     * Same as [[[[#loading[F[_],K,V](partitions:Int)*]]]], but with number of
     * paritions determined automatically using passed `Runtime` implementation.
+    *
+    * Minimal usage example:
+    * {{
+    * Cache.loading[F, String, User]
+    * }}
     */
   def loading[F[_]: Concurrent: Parallel: Runtime, K, V]: Resource[F, Cache[F, K, V]] = {
     loading(none)
@@ -171,6 +181,11 @@ object Cache {
     *
     * Same as [[#loading[F[_],K,V](partitions:Option[Int])*]], but without the
     * need to use `Option`.
+    *
+    * Minimal usage example:
+    * {{
+    * Cache.loading[F, String, User](partitions = 8)
+    * }}
     */
   def loading[F[_]: Concurrent: Parallel: Runtime, K, V](partitions: Int): Resource[F, Cache[F, K, V]] = {
     loading(partitions.some)
@@ -202,6 +217,11 @@ object Cache {
     *     [[Cache#put(key:K,value:V,release:Cache*]] and [[Cache#getOrUpdate1]]
     *     methods to be called in background without waiting for release to be
     *     completed.
+    *
+    * Minimal usage example:
+    * {{
+    * Cache.loading[F, String, User](partitions = None)
+    * }}
     *
     * @tparam F
     *   Effect type. See [[Cache]] for more details.
@@ -248,6 +268,14 @@ object Cache {
     * [[#loading[F[_],K,V](partitions:Option[Int])*]], this implementation also
     * adds [[cats.effect.Clock]] (as part of [[cats.effect.Temporal]]), to have
     * the ability to schedule cache clean up in a concurrent way.
+    *
+    * Minimal usage example:
+    * {{
+    * Cache.expiring[F, String, User](
+    *   config = ExpiringCache.Config(expireAfterRead = 1.minute),
+    *   partitions = None,
+    * )
+    * }}
     *
     * @tparam F
     *   Effect type. See [[#loading[F[_],K,V](partitions:Option[Int])*]] and

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -94,12 +94,11 @@ trait Cache[F[_], K, V] {
     */
   def getOrUpdate(key: K)(value: => F[V]): F[V]
 
-  /** Gets a value for specific key, or loads it using the provided function.
+   /** Gets a value for specific key, or loads it using the provided function.
     *
-    * The point of this method, comparing to [[#getOrUpdate]] is that it neither
-    * waits if value for a key is still loading, nor waits for a passed `value`
-    * function to complete, allowing the caller to not block while waiting for
-    * the result.
+    * The point of this method, comparing to [[#getOrUpdate]] is that it does
+    * not wait if value for a key is still loading, allowing the caller to not
+    * block while waiting for the result.
     *
     * It also allows some additional functionality similar to
     * [[#put(key:K,value:V,release:Option[*]].

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -109,11 +109,12 @@ object Cache {
 
   /** Creates an always-empty implementation of cache.
     *
-    * The implementation *almost* always returns `None` regardess the key. The
-    * notable exception are [[Cache#getOrUpdate]], [[Cache#getOrUpdate1]] and
-    * [[Cache#getOrUpdateOpt]] methods, which return the value passed to them to
-    * ensure the consistent behavior (i.e. it could be a suprise if someone
-    * calls [[Cache#getOrUpdateOpt]] with `Some` and gets `None` as a result).
+    * The implementation *almost* always returns [[scala.None]] regardess the
+    * key. The notable exception are [[Cache#getOrUpdate]],
+    * [[Cache#getOrUpdate1]] and [[Cache#getOrUpdateOpt]] methods, which return
+    * the value passed to them to ensure the consistent behavior (i.e. it could
+    * be a suprise if someone calls [[Cache#getOrUpdateOpt]] with [[scala.Some]]
+    * and gets [[scala.None]] as a result).
     *
     * It is meant to be used in tests, or as a stub in the code where cache
     * should be disabled.

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -151,18 +151,68 @@ trait Cache[F[_], K, V] {
     */
   def getOrUpdateOpt(key: K)(value: => F[Option[V]]): F[Option[V]]
 
-  /**
-    * @return previous value if any, possibly not yet loaded
+  /** Puts a value into cache under specific key.
+    *
+    * If the value is already being loaded (using [[#getOrUpdate]] method?) then
+    * the returned `F[_]` will wait for it to fully load, and then overwrite it.
+    *
+    * @param key
+    *   The key to store value for.
+    * @param value
+    *   The new value to put into the cache.
+    *
+    * @return
+    *   A previous value is returned if it was already added into the cache,
+    *   [[scala.None]] otherwise. The returned value is wrapped into `F[_]`
+    *   twice, because outer `F[_]` will complete when the value is put into
+    *   cache, but the second when `release` function passed to
+    *   [[#put(key:K,value:V,release:Cache*]] completes, i.e. the underlying
+    *   resource if fully released.
     */
   def put(key: K, value: V): F[F[Option[V]]]
 
-  /**
-    * @return previous value if any, possibly not yet loaded
+  /** Puts a value into cache under specific key.
+    *
+    * If the value is already being loaded (using [[#getOrUpdate]] method?) then
+    * the returned `F[_]` will wait for it to fully load, and then overwrite it.
+    *
+    * @param key
+    *   The key to store value for.
+    * @param value
+    *   The new value to put into the cache.
+    * @param release
+    *   The function to call when the value is removed from the cache.
+    *
+    * @return
+    *   A previous value is returned if it was already added into the cache,
+    *   [[scala.None]] otherwise. The returned value is wrapped into `F[_]`
+    *   twice, because outer `F[_]` will complete when the value is put into
+    *   cache, but the second when `release` function passed to
+    *   [[#put(key:K,value:V,release:Cache*]] completes, i.e. the underlying
+    *   resource if fully released.
     */
   def put(key: K, value: V, release: Release): F[F[Option[V]]]
 
-  /**
-    * @return previous value if any, possibly not yet loaded
+  /** Puts a value into cache under specific key.
+    *
+    * If the value is already being loaded (using [[#getOrUpdate]] method?) then
+    * the returned `F[_]` will wait for it to fully load, and then overwrite it.
+    *
+    * @param key
+    *   The key to store value for.
+    * @param value
+    *   The new value to put into the cache.
+    * @param release
+    *   The function to call when the value is removed from the cache.
+    *   No function will be called if it is set to [[scala.None]].
+    *
+    * @return
+    *   A previous value is returned if it was already added into the cache,
+    *   [[scala.None]] otherwise. The returned value is wrapped into `F[_]`
+    *   twice, because outer `F[_]` will complete when the value is put into
+    *   cache, but the second when `release` function passed to
+    *   [[#put(key:K,value:V,release:Cache*]] completes, i.e. the underlying
+    *   resource if fully released.
     */
   def put(key: K, value: V, release: Option[Release]): F[F[Option[V]]]
 

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -144,10 +144,6 @@ trait Cache[F[_], K, V] {
     * allows the loading function to fail finding the value, i.e. return
     * [[scala.None]].
     *
-    * Note, that this may not come for free in some implementations, i.e. some
-    * implementations use exceptions to bypass the loading mechanism internally,
-    * so the performance may suffer in this case.
-    *
     * @param key
     *   The key to return the value for.
     * @param value
@@ -786,9 +782,6 @@ object Cache {
       * this one allows the loading function to fail finding the value, i.e.
       * return [[scala.None]].
       *
-      * Note, that this may not come for free in some implementations, i.e. some
-      * implementations use exceptions to bypass the loading mechanism
-      * internally, so the performance may suffer in this case.
       *
       * Also this method is meant to be used where [[cats.effect.Resource]] is
       * not convenient to use, i.e. when integration with legacy code is
@@ -869,10 +862,6 @@ object Cache {
       * The difference between this method and [[#getOrUpdateResource]] is
       * that this one allows the loading function to fail finding the value,
       * i.e. return [[scala.None]].
-      *
-      * Note, that this may not come for free in some implementations, i.e. some
-      * implementations use exceptions to bypass the loading mechanism
-      * internally, so the performance may suffer in this case.
       *
       * @param key
       *   The key to return the value for.

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -807,10 +807,26 @@ object Cache {
         }
     }
 
-    /**
-      * Does not run `value` concurrently for the same key
-      * Resource will be release upon key removal from the cache
-      * In case of none returned, value will be ignored by cache
+    /** Gets a value for specific key, or tries to load it.
+      *
+      * The difference between this method and [[Cache#getOrUpdateResource]] is
+      * that this one allows the loading function to fail finding the value,
+      * i.e. return [[scala.None]].
+      *
+      * Note, that this may not come for free in some implementations, i.e. some
+      * implementations use exceptions to bypass the loading mechanism
+      * internally, so the performance may suffer in this case.
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @return
+      *   The same semantics applies as in [[#getOrUpdateResource]], except that
+      *   the method may return [[scala.None]] in case `value` completes to
+      *   [[scala.None]]. The resource will be released normally even if `None`
+      *   is returned.
       */
     def getOrUpdateResourceOpt(key: K)(value: => Resource[F, Option[V]])(implicit F: MonadCancel[F, Throwable]): F[Option[V]] = {
       self

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -281,7 +281,7 @@ object Cache {
 
   /** Creates a cache implementation, which is able remove the stale values.
     *
-    * The undelying storage implementation is the same as in
+    * The underlying storage implementation is the same as in
     * [[#loading[F[_],K,V](partitions:Option[Int])*]], but the expiration
     * routines are added on top of it.
     *

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -706,6 +706,11 @@ object Cache {
       }
     }
 
+    /** Prevents adding new keys with `release` after cache itself was released.
+      *
+      * This may be useful, for example, to prevent dangling cache references to
+      * be filled instead of an intended instance.
+      */
     def withFence(implicit F: Concurrent[F]): Resource[F, Cache[F, K, V]] = CacheFenced.of(self)
 
     /** Gets a value for specific key or uses another value.

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -120,12 +120,16 @@ trait Cache[F[_], K, V] {
     * not convenient to use, i.e. when integration with legacy code is required
     * or for internal implementation. For all other cases it is recommended to
     * use [[Cache.CacheOps#getOrUpdateResource]] instead as more human-readable
-    * alernative.
+    * alternative.
     *
     * @param key
     *   The key to return the value for.
     * @param value
     *   The function to run to load the missing value with.
+    *
+    * @tparam A
+    *   Arbitrary type of a value to return in case key was not present in a
+    *   cache.
     *
     * @return
     *   Either `A` passed as argument, if `key` was not found in cache, or
@@ -713,6 +717,33 @@ object Cache {
         }
     }
 
+    /** Gets a value for specific key, or loads it using a specified function.
+      *
+      * The difference between this method and [[Cache#getOrUpdate1]] is that
+      * this one does not differentiate between loading or loaded values present
+      * in a cache. If the value is still loading, `F[_]` will not complete
+      * until is is fully loaded.
+      *
+      * Also this method is meant to be used where [[cats.effect.Resource]] is
+      * not convenient to use, i.e. when integration with legacy code is
+      * required or for internal implementation. For all other cases it is
+      * recommended to use [[#getOrUpdateResource]] instead as more
+      * human-readable alternative.
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @tparam A
+      *   Arbitrary type of a value to return in case key was not present in a
+      *   cache.
+      *
+      * @return
+      *   The same semantics applies as in [[Cache#getOrUpdate1]], except that
+      *   in this method `F[_]` will only complete when the value is fully
+      *   loaded.
+      */
     def getOrUpdate2[A](
       key: K)(
       value: => F[(A, V, Option[Cache[F, K, V]#Release])])(implicit
@@ -737,16 +768,20 @@ object Cache {
       * implementations use exceptions to bypass the loading mechanism
       * internally, so the performance may suffer in this case.
       *
-      * Also, this method is meant to be used where [[cats.effect.Resource]] is
+      * Also this method is meant to be used where [[cats.effect.Resource]] is
       * not convenient to use, i.e. when integration with legacy code is
       * required or for internal implementation. For all other cases it is
       * recommended to use [[#getOrUpdateResourceOpt]] instead as more
-      * human-readable alernative.
+      * human-readable alternative.
       *
       * @param key
       *   The key to return the value for.
       * @param value
       *   The function to run to load the missing value with.
+      *
+      * @tparam A
+      *   Arbitrary type of a value to return in case key was not present in a
+      *   cache.
       *
       * @return
       *   The same semantics applies as in [[Cache#getOrUpdate1]], except that

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -185,7 +185,7 @@ object Cache {
     *   - [[cats.Parallel]] allows splitting underlying cache into multiple
     *     partitions, so there is no contention on a single [[cats.effect.Ref]]
     *     when cache need to be updated.
-    *   - `Runtime` is used to determine optimal number of partition based on
+    *   - `Runtime` is used to determine optimal number of partitions based on
     *     CPU count if the value is not provided as a parameter.
     *   - [[cats.effect.Sync]] (which comes as part of
     *     [[cats.effect.Concurrent]]), allows internal structures using
@@ -193,7 +193,7 @@ object Cache {
     *   - [[cats.effect.Concurrent]], allows `release` parameter in
     *     [[Cache#put(key:K,value:V,release:Cache*]] and [[Cache#getOrUpdate1]]
     *     methods to be called in background without waiting for release to be
-    *     complete.
+    *     completed.
     *
     * @tparam F
     *   Effect type. See [[Cache]] for more details.

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -74,9 +74,9 @@ trait Cache[F[_], K, V] {
   /** Gets a value for specific key, or loads it using the provided function.
     *
     * The method does not run `value` concurrently for the same key. I.e. if
-    * `F[_]` takes a time to be completed, and `getOrUpdate` is called several
-    * times then the consequent calls will not cause `F[_]` to be called, but
-    * will wait for the first one to complete.
+    * `value` takes a time to be completed, and [[#getOrUpdate]] is called
+    * several times, then the consequent calls will not cause `value` to be
+    * called, but will wait for the first one to complete.
     *
     * @param key
     *   The key to return the value for.
@@ -94,7 +94,7 @@ trait Cache[F[_], K, V] {
     */
   def getOrUpdate(key: K)(value: => F[V]): F[V]
 
-   /** Gets a value for specific key, or loads it using the provided function.
+  /** Gets a value for specific key, or loads it using the provided function.
     *
     * The point of this method, comparing to [[#getOrUpdate]] is that it does
     * not wait if value for a key is still loading, allowing the caller to not
@@ -104,13 +104,13 @@ trait Cache[F[_], K, V] {
     * [[#put(key:K,value:V,release:Option[*]].
     *
     * The method does not run `value` concurrently for the same key. I.e. if
-    * `F[_]` takes a time to be completed, and `getOrUpdate` is called several
-    * times then the consequent calls will not cause `F[_]` to be called, but
-    * will wait for the first one to complete.
+    * `value` takes a time to be completed, and [[#getOrUpdate1]] is called
+    * several times, then the consequent calls will not cause `value` to be
+    * called, but will wait for the first one to complete.
     *
     * The `value` is only called if `key` is not found, the tuple elements will
     * be used like following:
-    *   - `A` will be returned by [[#getOrUpdate]] to differentiate from the
+    *   - `A` will be returned by [[#getOrUpdate1]] to differentiate from the
     *     case when the value is already there,
     *   - `V` will be put to the cache,
     *   - `Release`, if present, will be called when this value is removed from

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -116,6 +116,12 @@ trait Cache[F[_], K, V] {
     *   - `Release`, if present, will be called when this value is removed from
     *     the cache.
     *
+    * Note: this method is meant to be used where [[cats.effect.Resource]] is
+    * not convenient to use, i.e. when integration with legacy code is required
+    * or for internal implementation. For all other cases it is recommended to
+    * use [[Cache.CacheOps#getOrUpdateResource]] instead as more human-readable
+    * alernative.
+    *
     * @param key
     *   The key to return the value for.
     * @param value

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -21,7 +21,7 @@ import scala.util.control.NoStackTrace
   *   parameter, the implementation is expected to abuse the fact that it is
   *   possible to call `hashCode` and `==` on any object in JVM. If performance
   *   is important, it is recommeded to limit `K` to the types where these
-  *   operations are fast such as `String` or `Integer`.
+  *   operations are fast such as `String`, `Integer` or a case class.
   * @tparam V
   *   Value type.
   */

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -232,8 +232,9 @@ object Cache {
 
   /** Creates a cache implementation, which is able remove the stale values.
     *
-    * The undelying storage implementation is the same as in [[#loading]], but
-    * the expiration routines are added on top of it.
+    * The undelying storage implementation is the same as in
+    * [[#loading[F[_],K,V](partitions:Option[Int])*]], but the expiration
+    * routines are added on top of it.
     *
     * Besides a value expiration leading to specific key being removed from the
     * cache, the implementation is capable of _refreshing_ the values instead of
@@ -241,12 +242,14 @@ object Cache {
     * setting or configuration service. The feature is possible to configure
     * using `config` parameter.
     *
-    * In adddition to context bounds used in [[#loading]], this implementation
-    * also adds [[cats.effect.Clock]] (as part of [[cats.effect.Temporal]]), to
-    * have the ability to schedule cache clean up in a concurrent way.
+    * In adddition to context bounds used in
+    * [[#loading[F[_],K,V](partitions:Option[Int])*]], this implementation also
+    * adds [[cats.effect.Clock]] (as part of [[cats.effect.Temporal]]), to have
+    * the ability to schedule cache clean up in a concurrent way.
     *
     * @tparam F
-    *   Effect type. See [[#loading]] and [[Cache]] for more details.
+    *   Effect type. See [[#loading[F[_],K,V](partitions:Option[Int])*]] and
+    *   [[Cache]] for more details.
     * @tparam K
     *   Key type. See [[Cache]] for more details.
     * @tparam V

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -304,7 +304,7 @@ object Cache {
     * It is only left public for sake of backwards compatibility.
     *
     * Please consider using either
-    * [[#loading[F[_],K,V](partitions:Option[Int])*]] or [[#expring]] instead.
+    * [[#loading[F[_],K,V](partitions:Option[Int])*]] or [[#expiring]] instead.
     *
     * Here is a short description of why some of the context bounds are required
     * on `F[_]`:

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -412,9 +412,9 @@ object Cache {
     *
     * @return
     *   A new instance of a cache wrapped into [[cats.effect.Resource]]. Note,
-    *   that [[#clear]] method will be called on underlying cache when resource
-    *   is released to make sure all resources stored in a cache are also
-    *   released.
+    *   that [[Cache#clear]] method will be called on underlying cache when
+    *   resource is released to make sure all resources stored in a cache are
+    *   also released.
     */
   def loading[F[_]: Concurrent: Parallel: Runtime, K, V]: Resource[F, Cache[F, K, V]] = {
     loading(none)
@@ -432,9 +432,9 @@ object Cache {
     *
     * @return
     *   A new instance of a cache wrapped into [[cats.effect.Resource]]. Note,
-    *   that [[#clear]] method will be called on underlying cache when resource
-    *   is released to make sure all resources stored in a cache are also
-    *   released.
+    *   that [[Cache#clear]] method will be called on underlying cache when
+    *   resource is released to make sure all resources stored in a cache are
+    *   also released.
     */
   def loading[F[_]: Concurrent: Parallel: Runtime, K, V](partitions: Int): Resource[F, Cache[F, K, V]] = {
     loading(partitions.some)
@@ -486,9 +486,9 @@ object Cache {
     *
     * @return
     *   A new instance of a cache wrapped into [[cats.effect.Resource]]. Note,
-    *   that [[#clear]] method will be called on underlying cache when resource
-    *   is released to make sure all resources stored in a cache are also
-    *   released.
+    *   that [[Cache#clear]] method will be called on underlying cache when
+    *   resource is released to make sure all resources stored in a cache are
+    *   also released.
     */
   def loading[F[_]: Concurrent: Parallel: Runtime, K, V](partitions: Option[Int] = None): Resource[F, Cache[F, K, V]] = {
 
@@ -550,9 +550,9 @@ object Cache {
     *
     * @return
     *   A new instance of a cache wrapped into [[cats.effect.Resource]]. Note,
-    *   that [[#clear]] method will be called on underlying cache when resource
-    *   is released to make sure all resources stored in a cache are also
-    *   released.
+    *   that [[Cache#clear]] method will be called on underlying cache when
+    *   resource is released to make sure all resources stored in a cache are
+    *   also released.
     */
   def expiring[F[_]: Temporal: Runtime: Parallel, K, V](
     config: ExpiringCache.Config[F, K, V],

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -167,7 +167,7 @@ trait Cache[F[_], K, V] {
     *   twice, because outer `F[_]` will complete when the value is put into
     *   cache, but the second when `release` function passed to
     *   [[#put(key:K,value:V,release:Cache*]] completes, i.e. the underlying
-    *   resource if fully released.
+    *   resource is fully released.
     */
   def put(key: K, value: V): F[F[Option[V]]]
 
@@ -189,7 +189,7 @@ trait Cache[F[_], K, V] {
     *   twice, because outer `F[_]` will complete when the value is put into
     *   cache, but the second when `release` function passed to
     *   [[#put(key:K,value:V,release:Cache*]] completes, i.e. the underlying
-    *   resource if fully released.
+    *   resource is fully released.
     */
   def put(key: K, value: V, release: Release): F[F[Option[V]]]
 
@@ -212,7 +212,7 @@ trait Cache[F[_], K, V] {
     *   twice, because outer `F[_]` will complete when the value is put into
     *   cache, but the second when `release` function passed to
     *   [[#put(key:K,value:V,release:Cache*]] completes, i.e. the underlying
-    *   resource if fully released.
+    *   resource is fully released.
     */
   def put(key: K, value: V, release: Option[Release]): F[F[Option[V]]]
 

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -269,14 +269,30 @@ trait Cache[F[_], K, V] {
     */
   def values1: F[Map[K, Either[F[V], V]]]
 
-  /**
-    * @return previous value if any, possibly not yet loaded
+  /** Removes a key from the cache, and also calls a release function.
+    *
+    * @return
+    *   A stored value is returned if such was present in the cache,
+    *   [[scala.None]] otherwise. The returned value is wrapped into `F[_]`
+    *   twice, because outer `F[_]` will complete when the value is put into
+    *   cache, but the second when `release` function passed to
+    *   [[#put(key:K,value:V,release:Cache*]] completes, i.e. the underlying
+    *   resource is fully released.
     */
   def remove(key: K): F[F[Option[V]]]
 
-
-  /**
-    * Removes loading values from the cache, however does not cancel them
+  /** Removes all the keys and their respective values from the cache.
+    *
+    * Both loaded and loading values are removed, and `release` function is
+    * called on them if present. The call does not cancel the loading values,
+    * but waits until these are fully loaded, instead.
+    *
+    * @return
+    *   The returned `Unit` is wrapped into `F[_]` twice, because outer
+    *   `F[Released]` will complete when the value is put into cache, but the
+    *   second `Released = F[Unit]` when `release` function passed to
+    *   [[#put(key:K,value:V,release:Cache*]] completes, i.e. the underlying
+    *   resource is fully released.
     */
   def clear: F[Released]
 

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -265,7 +265,7 @@ trait Cache[F[_], K, V] {
     *
     * @return
     *   All keys and values in the cache put into map. Loaded values are
-    *   returned as `Right(v)`, while loading are represented by `Left(F[V])`.
+    *   returned as `Right(v)`, while loading ones are represented by `Left(F[V])`.
     */
   def values1: F[Map[K, Either[F[V], V]]]
 

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -36,8 +36,31 @@ trait Cache[F[_], K, V] {
 
   type Released = F[Unit]
 
+  /** Gets a value for specific key.
+    *
+    *   - If the new value is loading (as result of [[#getOrUpdate]] or
+    *     implementation-specific refresh), then `F[_]` will not complete until
+    *     the value is fully loaded.
+    *   - `F[_]` will complete to `None` if there is no `key` present in the
+    *     cache.
+    */
   def get(key: K): F[Option[V]]
 
+  /** Gets a value for specific key.
+    *
+    * The point of this method, comparing to [[#get]] is that it does not wait
+    * if the value for a specific key is still loading, allowing the caller to
+    * not block while waiting for it.
+    *
+    *   - If the value is already in the cache then `F[_]` will complete to
+    *     `Some(Right(v))`.
+    *   - If the new value is loading (as result of [[#getOrUpdate]] or
+    *     implementation-specific refresh), then `F[_]` will complete to
+    *     `Some(Left(io))`, where `io` will not complete until the value is
+    *     fully loaded.
+    *   - `F[_]` will complete to `None` if there is no `key` present in the
+    *     cache.
+    */
   def get1(key: K): F[Option[Either[F[V], V]]]
 
   /**

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -46,8 +46,8 @@ trait Cache[F[_], K, V] {
     *   - If the new value is loading (as result of [[#getOrUpdate]] or
     *     implementation-specific refresh), then `F[_]` will not complete until
     *     the value is fully loaded.
-    *   - `F[_]` will complete to `None` if there is no `key` present in the
-    *     cache.
+    *   - `F[_]` will complete to [[scala.None]] if there is no `key` present in
+    *     the cache.
     */
   def get(key: K): F[Option[V]]
 
@@ -66,8 +66,8 @@ trait Cache[F[_], K, V] {
     *     implementation-specific refresh), then `F[_]` will complete to
     *     `Some(Left(io))`, where `io` will not complete until the value is
     *     fully loaded.
-    *   - `F[_]` will complete to `None` if there is no `key` present in the
-    *     cache.
+    *   - `F[_]` will complete to [[scala.None]] if there is no `key` present in
+    *     the cache.
     */
   def get1(key: K): F[Option[Either[F[V], V]]]
 
@@ -128,9 +128,20 @@ trait Cache[F[_], K, V] {
     */
   def getOrUpdate1[A](key: K)(value: => F[(A, V, Option[Release])]): F[Either[A, Either[F[V], V]]]
 
-  /**
-    * Does not run `value` concurrently for the same key
-    * In case of none returned, value will be ignored by cache
+  /** Gets a value for specific key, or tries to load it.
+    *
+    * The difference between this method and [[#getOrUpdate]] is that this one
+    * allows the loading function to fail finding the value, i.e. return
+    * [[scala.None]].
+    *
+    * Note, that this may not come for free in some implementations, i.e. some
+    * implementations use exceptions to bypass the loading mechanism internally,
+    * so the performance may suffer in this case.
+    *
+    * @return
+    *   The same semantics applies as in [[#getOrUpdate]], except that the
+    *   method may return [[scala.None]] in case `value` completes to
+    *   [[scala.None]].
     */
   def getOrUpdateOpt(key: K)(value: => F[Option[V]]): F[Option[V]]
 

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -307,9 +307,16 @@ trait Cache[F[_], K, V] {
     * }
     * }}}
     *
+    * @tparam A
+    *   Type to map the key/values to, and aggregate with. It requires
+    *   [[cats.kernel.CommutativeMonoid]] to be present to be able to sum up the
+    *   values, without having a guarantee about the order of the values being
+    *   aggregates as the order may be random depending on a cache
+    *   implementation.
+    *
     * @return
     *   Result of the aggregation, i.e. all mapped values combined using passed
-    *   `CommutativeMonoid`.
+    *   [[cats.kernel.CommutativeMonoid]].
     */
   def foldMap[A: CommutativeMonoid](f: (K, Either[F[V], V]) => F[A]): F[A]
 
@@ -326,9 +333,16 @@ trait Cache[F[_], K, V] {
     * }
     * }}}
     *
+    * @tparam A
+    *   Type to map the key/values to, and aggregate with. It requires
+    *   [[cats.kernel.CommutativeMonoid]] to be present to be able to sum up the
+    *   values, without having a guarantee about the order of the values being
+    *   aggregates as the order may be random depending on a cache
+    *   implementation.
+    *
     * @return
     *   Result of the aggregation, i.e. all mapped values combined using passed
-    *   `CommutativeMonoid`.
+    *   [[cats.kernel.CommutativeMonoid]].
     */
   def foldMapPar[A: CommutativeMonoid](f: (K, Either[F[V], V]) => F[A]): F[A]
 }

--- a/src/main/scala/com/evolution/scache/Cache.scala
+++ b/src/main/scala/com/evolution/scache/Cache.scala
@@ -63,8 +63,12 @@ trait Cache[F[_], K, V] {
     */
   def get1(key: K): F[Option[Either[F[V], V]]]
 
-  /**
-    * Does not run `value` concurrently for the same key
+  /** Gets a value for specific key, or loads it using the provided function.
+    *
+    * The method does not run `value` concurrently for the same key. I.e. if
+    * `F[_]` takes a time to be completed, and `getOrUpdate` is called several
+    * times then the consequent calls will not cause `F[_]` to be called, but
+    * will wait for the first one to complete.
     */
   def getOrUpdate(key: K)(value: => F[V]): F[V]
 

--- a/src/main/scala/com/evolution/scache/ExpiringCache.scala
+++ b/src/main/scala/com/evolution/scache/ExpiringCache.scala
@@ -398,7 +398,7 @@ object ExpiringCache {
     *   i.e. there is possibility that value is still there after it expires.
     * @param maxSize
     *   If set then the cache implementation will try to keep the cache size
-    *   under `maxSize` whenever clean up routine happens. It the cache size
+    *   under `maxSize` whenever clean up routine happens. If the cache size
     *   exceeds the value, it will try to drop part of non-expired element
     *   sorted by the timestamp, when these elements were last read. There is
     *   no guarantee, though, that this size will not be exceeded a bit, if

--- a/src/main/scala/com/evolution/scache/ExpiringCache.scala
+++ b/src/main/scala/com/evolution/scache/ExpiringCache.scala
@@ -333,6 +333,14 @@ object ExpiringCache {
 
   /** Configuration of a refresh background job.
     *
+    * Usage example (`SettingService.get` returns `F[Option[Setting]]`):
+    * {{
+    * ExpiringCache.Refresh(
+    *   interval = 1.minute,
+    *   value = key => SettingService.getOrNone(key)
+    * )
+    * }}
+    *
     * @param interval
     *   How often the refresh routine should be called. Note, that all cache
     *   entries will be refreshed regardless how long ago these were added to
@@ -364,6 +372,18 @@ object ExpiringCache {
     * actually done more often, for sake of faster cleanup), so the very small
     * value set for any of these parameters may affect the performance of the
     * cache, as cleanup will happen too often.
+    *
+    * Usage example (`SettingService.get` returns `F[Option[Setting]]`):
+    * {{
+    * ExpiringCache.Config(
+    *   expireAfterRead = 1.minute,
+    *   expireAfterWrite = None,
+    *   maxSize = None,
+    *   refresh = Some(ExpiringCache.Refresh(
+    *     interval = 1.minute,
+    *     value = key => SettingService.get(key)
+    *   ))
+    * }}
     *
     * @param expireAfterRead
     *   The value will be removed after the period set by this parameter if it

--- a/src/main/scala/com/evolution/scache/ExpiringCache.scala
+++ b/src/main/scala/com/evolution/scache/ExpiringCache.scala
@@ -334,12 +334,12 @@ object ExpiringCache {
   /** Configuration of a refresh background job.
     *
     * Usage example (`SettingService.get` returns `F[Option[Setting]]`):
-    * {{
+    * {{{
     * ExpiringCache.Refresh(
     *   interval = 1.minute,
     *   value = key => SettingService.getOrNone(key)
     * )
-    * }}
+    * }}}
     *
     * @param interval
     *   How often the refresh routine should be called. Note, that all cache
@@ -374,7 +374,7 @@ object ExpiringCache {
     * cache, as cleanup will happen too often.
     *
     * Usage example (`SettingService.get` returns `F[Option[Setting]]`):
-    * {{
+    * {{{
     * ExpiringCache.Config(
     *   expireAfterRead = 1.minute,
     *   expireAfterWrite = None,
@@ -383,7 +383,7 @@ object ExpiringCache {
     *     interval = 1.minute,
     *     value = key => SettingService.get(key)
     *   ))
-    * }}
+    * }}}
     *
     * @param expireAfterRead
     *   The value will be removed after the period set by this parameter if it

--- a/src/main/scala/com/evolution/scache/ExpiringCache.scala
+++ b/src/main/scala/com/evolution/scache/ExpiringCache.scala
@@ -409,7 +409,7 @@ object ExpiringCache {
     *   keys not already present in a cache will not be affected anyhow. See
     *   [[Refresh]] documentation for more details.
     */
-  case class Config[F[_], -K, V](
+  final case class Config[F[_], -K, V](
     expireAfterRead: FiniteDuration,
     expireAfterWrite: Option[FiniteDuration] = None,
     maxSize: Option[Int] = None,


### PR DESCRIPTION
Note: the documentation for `put` methods is now mentioning that internal effect in `F[F[T]]` is meant to wait for a resource to be released. I am not completely sure about that mechanism, so I suggest to review the comment before merge.