### PR TITLE
Fix release race conditions and refactor core flows

### DIFF
--- a/src/main/scala/com/evolution/scache/ExpiringCache.scala
+++ b/src/main/scala/com/evolution/scache/ExpiringCache.scala
@@ -51,7 +51,7 @@ object ExpiringCache {
                 result            <- if (expired) remove(key) else ().pure[F]
               } yield result
             case EntryState.Loading(_) => ().pure[F]
-            case EntryState.Removed(_) => ().pure[F]
+            case EntryState.Removed => ().pure[F]
           }
       }
 
@@ -70,7 +70,7 @@ object ExpiringCache {
                   .map {
                     case EntryState.Value(a) => Elem(key, a.value.touched) :: result
                     case EntryState.Loading(_) => result
-                    case EntryState.Removed(_) => result
+                    case EntryState.Removed => result
                   }
               }
             }
@@ -118,7 +118,7 @@ object ExpiringCache {
                     }
                     .handleError { _ => () }
                 case EntryState.Loading(_) => ().pure[F]
-                case EntryState.Removed(_) => ().pure[F]
+                case EntryState.Removed => ().pure[F]
               }
           }
         }

--- a/src/main/scala/com/evolution/scache/ExpiringCache.scala
+++ b/src/main/scala/com/evolution/scache/ExpiringCache.scala
@@ -5,6 +5,7 @@ import cats.effect.syntax.all.*
 import cats.kernel.CommutativeMonoid
 import cats.syntax.all.*
 import cats.{Applicative, Monad, MonadThrow, Monoid}
+import com.evolution.scache.LoadingCache.EntryState
 import com.evolutiongaming.catshelper.ClockHelper.*
 import com.evolutiongaming.catshelper.Schedule
 
@@ -40,8 +41,8 @@ object ExpiringCache {
       def removeExpired(key: K, entryRef: LoadingCache.EntryRef[F, Entry[V]]) = {
         entryRef
           .get
-          .flatMap { entry =>
-            entry.foldMapM { entry =>
+          .flatMap {
+            case EntryState.Value(entry) =>
               for {
                 now               <- Clock[F].millis
                 expiredAfterRead   = expireAfterReadMs + entry.value.touched < now
@@ -49,7 +50,8 @@ object ExpiringCache {
                 expired            = expiredAfterRead || expiredAfterWrite()
                 result            <- if (expired) remove(key) else ().pure[F]
               } yield result
-            }
+            case EntryState.Loading(_) => ().pure[F]
+            case EntryState.Removed(_) => ().pure[F]
           }
       }
 
@@ -66,8 +68,9 @@ object ExpiringCache {
                 entryRef
                   .get
                   .map {
-                    case Right(a) => Elem(key, a.value.touched) :: result
-                    case Left(_)  => result
+                    case EntryState.Value(a) => Elem(key, a.value.touched) :: result
+                    case EntryState.Loading(_) => result
+                    case EntryState.Removed(_) => result
                   }
               }
             }
@@ -105,8 +108,8 @@ object ExpiringCache {
           entryRefs.foldMapM { case (key, entryRef) =>
             entryRef
               .get
-              .flatMap { value =>
-                value.foldMapM { _ =>
+              .flatMap {
+                case EntryState.Value(_) =>
                   refresh
                     .value(key)
                     .flatMap {
@@ -114,7 +117,8 @@ object ExpiringCache {
                       case None        => cache.remove(key).void
                     }
                     .handleError { _ => () }
-                }
+                case EntryState.Loading(_) => ().pure[F]
+                case EntryState.Removed(_) => ().pure[F]
               }
           }
         }

--- a/src/main/scala/com/evolution/scache/LoadingCache.scala
+++ b/src/main/scala/com/evolution/scache/LoadingCache.scala
@@ -384,25 +384,21 @@ private[scache] object LoadingCache {
                               case true =>
                                 Concurrent[F]
                                   .asInstanceOf[Async[F]]
-                                  .delay(println(s"Releasing ${entry.value} from inside put")) *>
+                                  .delay(println(s"Releasing ${entry0.value} from inside put")) *>
                                 entry0
-//                                  .value
-//                                  .some
-//                                  .pure[F]
                                   .release
                                   .traverse { _.start }
                                   .map { fiber =>
                                     fiber
                                       .foldMapM { _.joinWithNever }
-                                      .flatMap { _ =>
+                                      .flatTap { _ =>
                                         Concurrent[F]
                                           .asInstanceOf[Async[F]]
-                                          .delay(println(s"Released ${entry.value} from inside put"))
+                                          .delay(println(s"Released ${entry0.value} from inside put"))
                                       }
                                       .as { entry0.value.some }
                                       .asRight[Int] // Breaking outer cycle
                                       .asRight[Int] // Breaking inner cycle
-//                                  .pure[F]
                                   }
                               case false =>
                                 (counter + 1)

--- a/src/main/scala/com/evolution/scache/LoadingCache.scala
+++ b/src/main/scala/com/evolution/scache/LoadingCache.scala
@@ -290,7 +290,7 @@ private[scache] object LoadingCache {
 
       def put(key: K, value: V, release: Option[Release]): F[F[Option[V]]] = {
         val entry = entryOf(value, release)
-        0.tailRecM { counter0 =>
+        0.tailRecM { counter =>
           ref
             .access
             .flatMap { case (entryRefs, set) =>
@@ -307,7 +307,7 @@ private[scache] object LoadingCache {
                             .pure[F]
                             .asRight[Int]
                         case false =>
-                          (counter0 + 1)
+                          (counter + 1)
                             .asLeft[F[Option[V]]]
                       }
                     }
@@ -472,7 +472,7 @@ private[scache] object LoadingCache {
 
 
       def remove(key: K): F[F[Option[V]]] = {
-        0.tailRecM { counter0 =>
+        0.tailRecM { counter =>
           ref
             .access
             .flatMap { case (entryRefs, set) =>
@@ -521,7 +521,7 @@ private[scache] object LoadingCache {
                                 .pure[F]
                           }
                       case false =>
-                        (counter0 + 1)
+                        (counter + 1)
                           .asLeft[F[Option[V]]]
                           .pure[F]
                     }

--- a/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -1167,7 +1167,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
           for {
             resultRef1 <- Ref[IO].of(0)
             resultRef2 <- Ref[IO].of(0)
-            range = 1 to 10_000
+            range = 1 to 100_000
 
             // For `getOrUpdate*` we don't know how many times the resource will be run,
             // so we use increment/decrement as a way to check that the resource is released exactly once.
@@ -1198,7 +1198,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         .use { cache =>
           for {
             resultRef <- Ref[IO].of(0)
-            range = 1 to 10_000
+            range = 1 to 100_000
 
             f1 <- (range: Seq[Int]).parTraverse(i => cache.put(0, 0, resultRef.update(_ + i))).start
             f2 <- (range: Seq[Int]).parTraverse(_ => cache.remove(0)).start
@@ -1210,9 +1210,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
             _ <- cache.clear.flatten
 
             result <- resultRef.get
-            _ <- IO {
-              result shouldEqual expectedResult
-            }
+            _ <- IO { result shouldEqual expectedResult }
           } yield ()
         }
         .run()
@@ -1224,7 +1222,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
           for {
             resultRef1 <- Ref[IO].of(0)
             resultRef2 <- Ref[IO].of(0)
-            range = 1 to 10_000
+            range = 1 to 100_000
 
             // For `getOrUpdate*` we don't know how many times the resource will be run,
             // so we use increment/decrement as a way to check that the resource is released exactly once.
@@ -1248,6 +1246,53 @@ class CacheSpec extends AsyncFunSuite with Matchers {
             result2 <- resultRef2.get
             _ <- IO { result1 shouldEqual 0 }
             _ <- IO { result2 shouldEqual expectedResult }
+          } yield ()
+        }
+        .run()
+    }
+
+    test(s"failing loads don't interfere with releases during `getOrUpdate1`, `put` and `remove` race: $name") {
+      cache
+        .use { cache =>
+          for {
+            resultRef1 <- Ref[IO].of(0)
+            resultRef2 <- Ref[IO].of(0)
+            resultRef3 <- Ref[IO].of(0)
+            range = 1 to 100_000
+
+            // For `getOrUpdate*` we don't know how many times the resource will be run,
+            // so we use increment/decrement as a way to check that the resource is released exactly once.
+            valueResource = (i: Int) => Resource.make(resultRef1.update(_ + i).as(i))(_ => resultRef1.update(_ - i))
+            f1 <- (range: Seq[Int]).parTraverse { i =>
+              cache.getOrUpdateResource(0)(valueResource(i)).recover(_ => -1)
+            }.start
+
+            failingResource = (i: Int) =>
+              Resource.make(new Exception("Boom").raiseError[IO, Int])(_ => resultRef2.update(_ - i))
+            f2 <- (range: Seq[Int]).parTraverse { i =>
+              cache.getOrUpdateResource(0)(failingResource(i)).recover(_ => -1)
+            }.start
+
+            // For `put` we know that the resource will be written and released every time,
+            // so we increment on release and check that the final value is equal to the sum of the range.
+            f3 <- (range: Seq[Int]).parTraverse(i => cache.put(0, 0, resultRef3.update(_ + i))).start
+
+            f4 <- (range: Seq[Int]).parTraverse(_ => cache.remove(0)).start
+
+            expectedResult = range.sum
+
+            _ <- f1.joinWithNever.void
+            _ <- f2.joinWithNever.void
+            _ <- f3.joinWithNever.flatMap(_.sequence)
+            _ <- f4.joinWithNever.flatMap(_.sequence)
+            _ <- cache.clear.flatten
+
+            result1 <- resultRef1.get
+            result2 <- resultRef2.get
+            result3 <- resultRef3.get
+            _ <- IO { result1 shouldEqual 0 }
+            _ <- IO { result2 shouldEqual 0 }
+            _ <- IO { result3 shouldEqual expectedResult }
           } yield ()
         }
         .run()

--- a/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -39,7 +39,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
       } yield (cache, metrics)
 
     def check(testName: String)(assertions: (Cache[IO, Int, Int], CacheMetricsProbe) => IO[Any]): Unit = test(testName) {
-      cacheAndMetrics.use(assertions.tupled).run()
+      cacheAndMetrics.use(assertions.tupled).run(timeout = 20.seconds)
     }
 
     check(s"get: $name") { (cache, metrics) =>

--- a/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -833,7 +833,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         value    <- value0.joinWithNever
         _        <- IO { value shouldEqual 0.asRight }
         value    <- value1
-        _        <- IO { value shouldEqual 0.some }
+        _        <- IO { value shouldEqual None }
         _        <- metrics.expect(
           metrics.expectedGet(hit = false)     -> 1,
           metrics.expectedLoad(success = true) -> 1,
@@ -855,9 +855,10 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         value    <- value1.startEnsure
         _        <- release.complete(())
         value    <- value.joinWithNever
+        _        <- IO.sleep(10.millis)
         released <- released.get
         _        <- IO { released shouldEqual true }
-        _        <- IO { value shouldEqual 0.some }
+        _        <- IO { value shouldEqual None }
         _        <- metrics.expect(
           metrics.expectedGet(hit = false)     -> 1,
           metrics.expectedLoad(success = true) -> 1,
@@ -1161,145 +1162,129 @@ class CacheSpec extends AsyncFunSuite with Matchers {
       } yield {}
     }
 
-    test(s"each release performed exactly once during `getOrUpdate1` and `put` race: $name") {
-      cache
-        .use { cache =>
-          for {
-            resultRef1 <- Ref[IO].of(0)
-            resultRef2 <- Ref[IO].of(0)
-            n = 100000
-            range = (1 to n).toList
+    check(s"each release performed exactly once during `getOrUpdate1` and `put` race: $name") { (cache, metrics) =>
+      for {
+        resultRef1 <- Ref[IO].of(0)
+        resultRef2 <- Ref[IO].of(0)
+        n = 100000
+        range = (1 to n).toList
 
-            // For `getOrUpdate*` we don't know how many times the resource will be run,
-            // so we use increment/decrement as a way to check that the resource is released exactly once.
-            valueResource = (i: Int) => Resource.make(resultRef1.update(_ + i).as(i))(_ => resultRef1.update(_ - i))
-            f1 <- range.parTraverse { i => cache.getOrUpdateResource(0)(valueResource(i)) }.start
+        // For `getOrUpdate*` we don't know how many times the resource will be run,
+        // so we use increment/decrement as a way to check that the resource is released exactly once.
+        valueResource = (i: Int) => Resource.make(resultRef1.update(_ + i).as(i))(_ => resultRef1.update(_ - i))
+        f1 <- range.parTraverse { i => cache.getOrUpdateResource(0)(valueResource(i)) }.start
 
-            // For `put` we know that the resource will be written and released every time,
-            // so we increment on release and check that the final value is equal to the sum of the range.
-            f2 <- range.parTraverse(i => cache.put(0, 0, resultRef2.update(_ + i))).start
+        // For `put` we know that the resource will be written and released every time,
+        // so we increment on release and check that the final value is equal to the sum of the range.
+        f2 <- range.parTraverse(i => cache.put(0, 0, resultRef2.update(_ + i))).start
 
-            expectedResult = range.sum
+        expectedResult = range.sum
 
-            _ <- f1.joinWithNever.void
-            _ <- f2.joinWithNever.flatMap(_.sequence)
-            _ <- cache.clear.flatten
+        _ <- f1.joinWithNever.void
+        _ <- f2.joinWithNever.flatMap(_.sequence)
+        _ <- cache.clear.flatten
 
-            result1 <- resultRef1.get
-            result2 <- resultRef2.get
-            _ <- IO { result1 shouldEqual 0 }
-            _ <- IO { result2 shouldEqual expectedResult }
-          } yield ()
-        }
-        .run()
+        result1 <- resultRef1.get
+        result2 <- resultRef2.get
+        _ <- IO { result1 shouldEqual 0 }
+        _ <- IO { result2 shouldEqual expectedResult }
+      } yield {}
     }
 
-    test(s"each release performed exactly once during `put` and `remove` race: $name") {
-      cache
-        .use { cache =>
-          for {
-            resultRef <- Ref[IO].of(0)
-            n = 100000
-            range = (1 to n).toList
+    check(s"each release performed exactly once during `put` and `remove` race: $name") { (cache, metrics) =>
+      for {
+        resultRef <- Ref[IO].of(0)
+        n = 100000
+        range = (1 to n).toList
 
-            f1 <- range.parTraverse(i => cache.put(0, 0, resultRef.update(_ + i))).start
-            f2 <- cache.remove(0).replicateA(n).start
+        f1 <- range.parTraverse(i => cache.put(0, 0, resultRef.update(_ + i))).start
+        f2 <- cache.remove(0).replicateA(n).start
 
-            expectedResult = range.sum
+        expectedResult = range.sum
 
-            _ <- f1.joinWithNever.flatMap(_.sequence)
-            _ <- f2.joinWithNever.flatMap(_.sequence)
-            _ <- cache.clear.flatten
+        _ <- f1.joinWithNever.flatMap(_.sequence)
+        _ <- f2.joinWithNever.flatMap(_.sequence)
+        _ <- cache.clear.flatten
 
-            result <- resultRef.get
-            _ <- IO { result shouldEqual expectedResult }
-          } yield ()
-        }
-        .run()
+        result <- resultRef.get
+        _ <- IO { result shouldEqual expectedResult }
+      } yield {}
     }
 
-    test(s"each release performed exactly once during `getOrUpdate1`, `put` and `remove` race: $name") {
-      cache
-        .use { cache =>
-          for {
-            resultRef1 <- Ref[IO].of(0)
-            resultRef2 <- Ref[IO].of(0)
-            n = 100000
-            range = (1 to n).toList
+    check(s"each release performed exactly once during `getOrUpdate1`, `put` and `remove` race: $name") { (cache, metrics) =>
+      for {
+        resultRef1 <- Ref[IO].of(0)
+        resultRef2 <- Ref[IO].of(0)
+        n = 100000
+        range = (1 to n).toList
 
-            // For `getOrUpdate*` we don't know how many times the resource will be run,
-            // so we use increment/decrement as a way to check that the resource is released exactly once.
-            valueResource = (i: Int) => Resource.make(resultRef1.update(_ + i).as(i))(_ => resultRef1.update(_ - i))
-            f1 <- range.parTraverse { i => cache.getOrUpdateResource(0)(valueResource(i)) }.start
+        // For `getOrUpdate*` we don't know how many times the resource will be run,
+        // so we use increment/decrement as a way to check that the resource is released exactly once.
+        valueResource = (i: Int) => Resource.make(resultRef1.update(_ + i).as(i))(_ => resultRef1.update(_ - i))
+        f1 <- range.parTraverse { i => cache.getOrUpdateResource(0)(valueResource(i)) }.start
 
-            // For `put` we know that the resource will be written and released every time,
-            // so we increment on release and check that the final value is equal to the sum of the range.
-            f2 <- range.parTraverse(i => cache.put(0, 0, resultRef2.update(_ + i))).start
+        // For `put` we know that the resource will be written and released every time,
+        // so we increment on release and check that the final value is equal to the sum of the range.
+        f2 <- range.parTraverse(i => cache.put(0, 0, resultRef2.update(_ + i))).start
 
-            f3 <- cache.remove(0).replicateA(n).start
+        f3 <- cache.remove(0).replicateA(n).start
 
-            expectedResult = range.sum
+        expectedResult = range.sum
 
-            _ <- f1.joinWithNever.void
-            _ <- f2.joinWithNever.flatMap(_.sequence)
-            _ <- f3.joinWithNever.flatMap(_.sequence)
-            _ <- cache.clear.flatten
+        _ <- f1.joinWithNever.void
+        _ <- f2.joinWithNever.flatMap(_.sequence)
+        _ <- f3.joinWithNever.flatMap(_.sequence)
+        _ <- cache.clear.flatten
 
-            result1 <- resultRef1.get
-            result2 <- resultRef2.get
-            _ <- IO { result1 shouldEqual 0 }
-            _ <- IO { result2 shouldEqual expectedResult }
-          } yield ()
-        }
-        .run()
+        result1 <- resultRef1.get
+        result2 <- resultRef2.get
+        _ <- IO { result1 shouldEqual 0 }
+        _ <- IO { result2 shouldEqual expectedResult }
+      } yield {}
     }
 
-    test(s"failing loads don't interfere with releases during `getOrUpdate1`, `put` and `remove` race: $name") {
-      cache
-        .use { cache =>
-          for {
-            resultRef1 <- Ref[IO].of(0)
-            resultRef2 <- Ref[IO].of(0)
-            resultRef3 <- Ref[IO].of(0)
-            n = 100000
-            range = (1 to n).toList
+    check(s"failing loads don't interfere with releases during `getOrUpdate1`, `put` and `remove` race: $name") { (cache, metrics) =>
+      for {
+        resultRef1 <- Ref[IO].of(0)
+        resultRef2 <- Ref[IO].of(0)
+        resultRef3 <- Ref[IO].of(0)
+        n = 100000
+        range = (1 to n).toList
 
-            // For `getOrUpdate*` we don't know how many times the resource will be run,
-            // so we use increment/decrement as a way to check that the resource is released exactly once.
-            valueResource = (i: Int) => Resource.make(resultRef1.update(_ + i).as(i))(_ => resultRef1.update(_ - i))
-            f1 <- range.parTraverse { i =>
-              cache.getOrUpdateResource(0)(valueResource(i)).recover { case _ => -1 }
-            }.start
+        // For `getOrUpdate*` we don't know how many times the resource will be run,
+        // so we use increment/decrement as a way to check that the resource is released exactly once.
+        valueResource = (i: Int) => Resource.make(resultRef1.update(_ + i).as(i))(_ => resultRef1.update(_ - i))
+        f1 <- range.parTraverse { i =>
+          cache.getOrUpdateResource(0)(valueResource(i)).recover { case _ => -1 }
+        }.start
 
-            failingResource = (i: Int) =>
-              Resource.make(new Exception("Boom").raiseError[IO, Int])(_ => resultRef2.update(_ - i))
-            f2 <- range.parTraverse { i =>
-              cache.getOrUpdateResource(0)(failingResource(i)).recover { case _ => -1 }
-            }.start
+        failingResource = (i: Int) =>
+          Resource.make(new Exception("Boom").raiseError[IO, Int])(_ => resultRef2.update(_ - i))
+        f2 <- range.parTraverse { i =>
+          cache.getOrUpdateResource(0)(failingResource(i)).recover { case _ => -1 }
+        }.start
 
-            // For `put` we know that the resource will be written and released every time,
-            // so we increment on release and check that the final value is equal to the sum of the range.
-            f3 <- range.parTraverse(i => cache.put(0, 0, resultRef3.update(_ + i))).start
+        // For `put` we know that the resource will be written and released every time,
+        // so we increment on release and check that the final value is equal to the sum of the range.
+        f3 <- range.parTraverse(i => cache.put(0, 0, resultRef3.update(_ + i))).start
 
-            f4 <- cache.remove(0).parReplicateA(n).start
+        f4 <- cache.remove(0).parReplicateA(n).start
 
-            expectedResult = range.sum
+        expectedResult = range.sum
 
-            _ <- f1.joinWithNever.void
-            _ <- f2.joinWithNever.void
-            _ <- f3.joinWithNever.flatMap(_.sequence)
-            _ <- f4.joinWithNever.flatMap(_.sequence)
-            _ <- cache.clear.flatten
+        _ <- f1.joinWithNever.void
+        _ <- f2.joinWithNever.void
+        _ <- f3.joinWithNever.flatMap(_.sequence)
+        _ <- f4.joinWithNever.flatMap(_.sequence)
+        _ <- cache.clear.flatten
 
-            result1 <- resultRef1.get
-            result2 <- resultRef2.get
-            result3 <- resultRef3.get
-            _ <- IO { result1 shouldEqual 0 }
-            _ <- IO { result2 shouldEqual 0 }
-            _ <- IO { result3 shouldEqual expectedResult }
-          } yield ()
-        }
-        .run()
+        result1 <- resultRef1.get
+        result2 <- resultRef2.get
+        result3 <- resultRef3.get
+        _ <- IO { result1 shouldEqual 0 }
+        _ <- IO { result2 shouldEqual 0 }
+        _ <- IO { result3 shouldEqual expectedResult }
+      } yield ()
     }
   }
 }

--- a/src/test/scala/com/evolution/scache/ExpiringCacheSpec.scala
+++ b/src/test/scala/com/evolution/scache/ExpiringCacheSpec.scala
@@ -275,12 +275,13 @@ class ExpiringCacheSpec extends AsyncFunSuite with Matchers {
         value    <- cache.get(0)
         _        <- Sync[F].delay { value shouldEqual 1.some }
         value    <- retryUntilNone(0)
+        _        <- Temporal[F].sleep(10.millis) // Account to `release` being performed asynchronously
         released <- released.get
         _        <- Sync[F].delay { released shouldEqual true}
         _        <- Sync[F].delay { value shouldEqual none }
         _        <- release.get
       } yield {}
-    }
+    }.replicateA_(20)
   }
 
 

--- a/src/test/scala/com/evolution/scache/ExpiringCacheSpec.scala
+++ b/src/test/scala/com/evolution/scache/ExpiringCacheSpec.scala
@@ -281,7 +281,7 @@ class ExpiringCacheSpec extends AsyncFunSuite with Matchers {
         _        <- Sync[F].delay { value shouldEqual none }
         _        <- release.get
       } yield {}
-    }.replicateA_(20)
+    }
   }
 
 


### PR DESCRIPTION
Test specs added demonstrate race conditions when performing `release` of values under the same key, when there are multiple concurrent `getOrUpdate1`, `put`, and `remove` operations being performed. Two of these specs (`put` + `remove`, and `getOrUpdate1` + `put` + `remove`) fail on the current master branch.

In short, there were several mix-ups as to which fiber should release which entry and in which case: some entries were being abandoned and not released after being removed, and for some, release was being performed more than once.