### PR TITLE
port changes from Scala 3 migration to Cats Effect 2 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         scala:
           - 2.13.11

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ scalaVersion := crossScalaVersions.value.head
 
 crossScalaVersions := Seq("2.13.11", "2.12.18")
 
+coverageExcludedFiles := ".*CacheOpsCompat.*"
+
 libraryDependencies ++= Seq(
   compilerPlugin(betterMonadicFor),
   compilerPlugin(`kind-projector` cross CrossVersion.full)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   val scalatest        = "org.scalatest"       %% "scalatest"          % "3.2.16"
-  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"        % "2.11.0"
+  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"        % "2.12.0"
   val smetrics         = "com.evolutiongaming" %% "smetrics"           % "0.5.0"
   val `kind-projector` = "org.typelevel"        % "kind-projector"     % "0.13.2"
   val betterMonadicFor = "com.olegpy"          %% "better-monadic-for" % "0.3.1"

--- a/src/main/scala-2/com/evolution/scache/CacheOpsCompat.scala
+++ b/src/main/scala-2/com/evolution/scache/CacheOpsCompat.scala
@@ -13,7 +13,7 @@ import cats.MonadThrow
   * 
   * But this is Cats Effect 2 branch and here it is just for the sake of consistency in sources between branches.
   */
-object CacheOpsCompat {
+private[scache] object CacheOpsCompat {
   private[scache] case object NoneError
       extends RuntimeException
       with NoStackTrace

--- a/src/main/scala-2/com/evolution/scache/CacheOpsCompat.scala
+++ b/src/main/scala-2/com/evolution/scache/CacheOpsCompat.scala
@@ -1,0 +1,105 @@
+package com.evolution.scache
+
+import cats.effect.Resource
+import cats.effect.BracketThrow
+import cats.syntax.all._
+
+import scala.util.control.NoStackTrace
+import cats.MonadThrow
+
+/** Compat is needed because there is a bug in Scala3 compiler, see
+  * https://github.com/lampepfl/dotty/issues/18099. Scala's 2 implementation
+  * crashes Scalas's 3 compiler.
+  * 
+  * But this is Cats Effect 2 branch and here it is just for the sake of consistency in sources between branches.
+  */
+object CacheOpsCompat {
+  private[scache] case object NoneError
+      extends RuntimeException
+      with NoStackTrace
+
+  implicit class CacheXtensionCompat[F[_], K, V](val self: Cache[F, K, V])
+      extends AnyVal {
+
+    /** Gets a value for specific key, or tries to load it.
+      *
+      * The difference between this method and [[Cache#getOrUpdate1]] is that
+      * this one allows the loading function to fail finding the value, i.e.
+      * return [[scala.None]].
+      *
+      * Also this method is meant to be used where [[cats.effect.Resource]] is
+      * not convenient to use, i.e. when integration with legacy code is
+      * required or for internal implementation. For all other cases it is
+      * recommended to use [[#getOrUpdateResourceOpt]] instead as more
+      * human-readable alternative.
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @tparam A
+      *   Arbitrary type of a value to return in case key was not present in a
+      *   cache.
+      *
+      * @return
+      *   The same semantics applies as in [[Cache#getOrUpdate1]], except that
+      *   the method may return [[scala.None]] in case `value` completes to
+      *   [[scala.None]].
+      */
+    def getOrUpdateOpt1Compat[A](key: K)(
+      value: => F[Option[(A, V, Option[Cache[F, K, V]#Release])]])(implicit
+      F: MonadThrow[F]
+    ): F[Option[Either[A, Either[F[V], V]]]] = {
+      self
+        .getOrUpdate1(key) {
+          value.flatMap {
+            case Some((a, value, release)) => (a, value, release).pure[F]
+            case None                      => NoneError.raiseError[F, (A, V, Option[Cache[F, K, V]#Release])]
+          }
+        }
+        .map { _.some }
+        .recover { case NoneError => none }
+    }
+
+    /** Gets a value for specific key, or tries to load it.
+      *
+      * The difference between this method and [[#getOrUpdateResource]] is that
+      * this one allows the loading function to fail finding the value,
+      * i.e. return [[scala.None]].
+      *
+      * @param key
+      *   The key to return the value for.
+      * @param value
+      *   The function to run to load the missing value with.
+      *
+      * @return
+      *   The same semantics applies as in [[#getOrUpdateResource]], except that
+      *   the method may return [[scala.None]] in case `value` completes to
+      *   [[scala.None]]. The resource will be released normally even if `None`
+      *   is returned.
+      */
+    def getOrUpdateResourceOptCompat(key: K)(value: => Resource[F, Option[V]])(implicit F: BracketThrow[F]): F[Option[V]] = {
+      self
+        .getOrUpdateOpt1(key) {
+          value
+            .allocated
+            .flatMap {
+              case (Some(a), release) =>
+                (a, a, release.some)
+                  .some
+                  .pure[F]
+              case (None, release)    =>
+                release.as { none[(V, V, Option[F[Unit]])] }
+            }
+        }
+        .flatMap {
+          case Some(Right(Right(a))) => a.some.pure[F]
+          case Some(Right(Left(a)))  => a.map { _.some }
+          case Some(Left(a))         => a.some.pure[F]
+          case None                  => none[V].pure[F]
+        }
+    }
+  }
+
+}

--- a/src/main/scala/com/evolution/scache/CacheMetered.scala
+++ b/src/main/scala/com/evolution/scache/CacheMetered.scala
@@ -69,7 +69,7 @@ object CacheMetered {
                 value      <- value.attempt
                 duration   <- start
                 loadSucceed = value match {
-                  case Right(_) | Left(Cache.NoneError) => true
+                  case Right(_) | Left(CacheOpsCompat.NoneError) => true
                   case Left(_)                          => false
                 }
                 _     <- metrics.load(duration, loadSucceed)

--- a/src/main/scala/com/evolution/scache/CacheMetrics.scala
+++ b/src/main/scala/com/evolution/scache/CacheMetrics.scala
@@ -72,9 +72,9 @@ object CacheMetrics {
     }
   }
   object Directive {
-    final case object Put extends Directive
-    final case object Ignore extends Directive
-    final case object Remove extends Directive
+    case object Put extends Directive
+    case object Ignore extends Directive
+    case object Remove extends Directive
   }
 
   type Name = String

--- a/src/main/scala/com/evolution/scache/LoadingCache.scala
+++ b/src/main/scala/com/evolution/scache/LoadingCache.scala
@@ -850,7 +850,7 @@ private[scache] object LoadingCache {
   object EntryState {
     final case class Loading[F[_], A](deferred: Deferred[F, Either[Throwable, Entry[F, A]]]) extends EntryState[F, A]
     final case class Value[F[_], A](entry: Entry[F, A]) extends EntryState[F, A]
-    final case object Removed extends EntryState[Nothing, Nothing]
+    case object Removed extends EntryState[Nothing, Nothing]
   }
 
   type DeferredThrow[F[_], A] = Deferred[F, Either[Throwable, A]]

--- a/src/main/scala/com/evolution/scache/SerialMap.scala
+++ b/src/main/scala/com/evolution/scache/SerialMap.scala
@@ -244,7 +244,10 @@ object SerialMap { self =>
 
   class Apply[F[_]](val F: Concurrent[F]) extends AnyVal {
 
-    def of[K, V](implicit runtime: Runtime[F]): F[SerialMap[F, K, V]] = self.of[F, K, V](F, runtime)
+    def of[K, V](implicit runtime: Runtime[F]): F[SerialMap[F, K, V]] = {
+      implicit val concurrent: Concurrent[F] = F
+      self.of[F, K, V](None)
+    }
   }
 
 


### PR DESCRIPTION
The main reason to port https://github.com/evolution-gaming/scache/pull/221 is to keep sources as closest as possible. In mentioned PR, `CacheOpsCompat` was created to patch issues with Scala 3 compiler. This PR ports scala-2 structure of mentioned compat.