### PR TITLE
chore: make  introduced compat package private

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 ## Key features
 
+* Available for: Scala 2.12.x, 2.13.x, 3.3.0 and later
 * Auto loading of missing values
 * Expiry of not used records
 * Deleting oldest values in case of exceeding max size
@@ -119,8 +120,13 @@ trait SerialMap[F[_], K, V] {
 
 ## Setup
 
+Although `scache` is available on maven central, its dependencies are not. That is why one need to include
+dependency on https://github.com/evolution-gaming/sbt-artifactory-plugin.
+
 ```scala
-libraryDependencies += "com.evolution" %% "scache" % "4.3.1.1"
+addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
+
+libraryDependencies += "com.evolution" %% "scache" % "5.1.2"
 ```
 
 ## ExpiringCache

--- a/src/main/scala-2/com/evolution/scache/CacheOpsCompat.scala
+++ b/src/main/scala-2/com/evolution/scache/CacheOpsCompat.scala
@@ -11,7 +11,7 @@ import scala.util.control.NoStackTrace
   * https://github.com/lampepfl/dotty/issues/18099. Scala's 2 implementation
   * crashes Scalas's 3 compiler.
   */
-object CacheOpsCompat {
+private[scache] object CacheOpsCompat {
   private[scache] case object NoneError
       extends RuntimeException
       with NoStackTrace

--- a/src/main/scala-3/com/evolution/scache/CacheOpsCompat.scala
+++ b/src/main/scala-3/com/evolution/scache/CacheOpsCompat.scala
@@ -11,7 +11,7 @@ import scala.util.control.NoStackTrace
   * https://github.com/lampepfl/dotty/issues/18099. Scala's 2 implementation
   * crashes Scalas's 3 compiler.
   */
-object CacheOpsCompat {
+private[scache] object CacheOpsCompat {
   private[scache] case object NoneError
       extends RuntimeException
       with NoStackTrace


### PR DESCRIPTION
2 birds with one ~stone~ PR. I also adjusted readme:
- scache cannot be used without adding external evo resolver, that's why I mentioned using `sbt-artifactory-plugin`.
- changed version in example to future 5.1.2 which has Scala3 support
- mentioned supported Scala versions, especially Scala 3 as a key feature. If it's the only one (or one of few) cache lib for TF Scala then it's surely Scala3 support is a feature.