### PR TITLE
Update dependencies; drop scala 2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,31 +54,3 @@ jobs:
           type: ${{ job.status }}
           job_name: Build
           url: ${{ secrets.SLACK_WEBHOOK }}
-
-  publish:
-    name: Publish Artifacts
-    needs: [test]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: coursier/cache-action@v6
-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: "sbt"
-
-      - name: setup SBT
-        uses: sbt/setup-sbt@v1
-
-      - name: Publish artifacts
-        env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASS }}
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        run: sbt ci-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,14 @@ jobs:
       - uses: coursier/cache-action@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "temurin"
           cache: "sbt"
+      
+      - name: setup SBT
+        uses: sbt/setup-sbt@v1
 
       - name: build ${{ matrix.scala }}
         run: sbt ++${{ matrix.scala }} clean coverage test
@@ -68,6 +71,9 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "sbt"
+
+      - name: setup SBT
+        uses: sbt/setup-sbt@v1
 
       - name: Publish artifacts
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         scala:
-          - 3.3.0
-          - 2.13.11
-          - 2.12.18
+          - 3.3.5
+          - 2.13.16
 
     steps:
       - uses: actions/checkout@v3
@@ -39,7 +38,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} clean coverage test
 
       - name: test coverage
-        if: success() && matrix.scala != '3.3.0'
+        if: success() && matrix.scala != '3.3.5'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
-name: Publish new Release
-
+name: Test and publish a new release
+  
 on:
-  release:
-    types: [published]
-    branches: [master]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   release:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
+    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v3
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Key features
 
-* Available for: Scala 2.12.x, 2.13.x, 3.3.0 and later
+* Available for: Scala 2.13.x, 3.3.0 and later
 * Auto loading of missing values
 * Expiry of not used records
 * Deleting oldest values in case of exceeding max size

--- a/README.md
+++ b/README.md
@@ -139,5 +139,9 @@ libraryDependencies += "com.evolution" %% "scache" % "5.1.2"
 * Touch, despite its name, is not called after refresh.
 * expireAfterWrite, despite its name, is calculated from date of creation, not time of update.
 
-
-
+## Release process
+The release process is based on Git tags and makes use of [evolution-gaming/scala-github-actions](https://github.com/evolution-gaming/scala-github-actions) which uses [sbt-dynver](https://github.com/sbt/sbt-dynver) to automatically obtain the version from the latest Git tag. The flow is defined in `.github/workflows/release.yml`.  
+A typical release process is as follows:
+1. Create and push a new Git tag. The version should be in the format `vX.Y.Z` (example: `v4.1.0`). Example: `git tag v4.1.0 && git push origin v4.1.0`
+2. On success, a new GitHub release is automatically created with a calculated diff and auto-generated release notes. You can see it on `Releases` page, change the description if needed
+3. On failure, the tag is deleted from the remote repository. Please note that your local tag isn't deleted, so if the failure is recoverable then you can delete the local tag and try again (an example of *unrecoverable* failure is successfully publishing only a few of the artifacts to Artifactory which means a new attempt would fail since Artifactory doesn't allow overwriting its contents)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Key features
 
-* Available for: Scala 2.13.x, 3.3.0 and later
+* Available for: Scala 2.13.x, 3.3.x and later
 * Auto loading of missing values
 * Expiry of not used records
 * Deleting oldest values in case of exceeding max size

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ coverageExcludedFiles := ".*CacheOpsCompat.*"
 
 scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("2.13.11", "3.3.0", "2.12.18")
+crossScalaVersions := Seq("2.13.16", "3.3.5")
 
 scalacOptsFailOnWarn := crossSettings(
   scalaVersion.value,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,14 +2,14 @@ import sbt.*
 
 object Dependencies {
 
-  val scalatest        = "org.scalatest"       %% "scalatest"          % "3.2.16"
-  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"        % "3.6.0"
-  val smetrics         = "com.evolutiongaming" %% "smetrics"           % "2.0.0"
-  val `kind-projector` = "org.typelevel"        % "kind-projector"     % "0.13.2"
+  val scalatest        = "org.scalatest"       %% "scalatest"          % "3.2.19"
+  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"        % "3.11.3"
+  val smetrics         = "com.evolutiongaming" %% "smetrics"           % "2.2.0"
+  val `kind-projector` = "org.typelevel"        % "kind-projector"     % "0.13.3"
   val betterMonadicFor = "com.olegpy"          %% "better-monadic-for" % "0.3.1"
 
   object Cats {
-    val core   = "org.typelevel" %% "cats-core"   % "2.9.0"
-    val effect = "org.typelevel" %% "cats-effect" % "3.4.11"
+    val core   = "org.typelevel" %% "cats-core"   % "2.13.0"
+    val effect = "org.typelevel" %% "cats-effect" % "3.5.7"
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,8 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
+// This sets the 'version' property based on the git tag during release process to publish the right version
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.0")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.9")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 

--- a/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -28,7 +28,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
       ("default"               , Cache.loading[IO, Int, Int]),
       ("no partitions"         , LoadingCache.of(LoadingCache.EntryRefs.empty[IO, Int, Int])),
       ("expiring"              , expiringCache),
-      ("expiring no partitions", ExpiringCache.of[IO, Int, Int](ExpiringCache.Config(expireAfterRead = 1.minute))))
+      ("expiring no partitions", ExpiringCache.of[IO, Int, Int](ExpiringCache.Config[IO, Int, Int](expireAfterRead = 1.minute))))
   } yield {
 
     val cacheAndMetrics =

--- a/src/test/scala/com/evolution/scache/ExpiringCacheSpec.scala
+++ b/src/test/scala/com/evolution/scache/ExpiringCacheSpec.scala
@@ -45,7 +45,7 @@ class ExpiringCacheSpec extends AsyncFunSuite with Matchers {
 
   private def expireRecords[F[_] : Async] = {
 
-    ExpiringCache.of[F, Int, Int](ExpiringCache.Config(expireAfterRead = 100.millis)).use { cache =>
+    ExpiringCache.of[F, Int, Int](ExpiringCache.Config[F, Int, Int](expireAfterRead = 100.millis)).use { cache =>
       for {
         release <- Deferred[F, Unit]
         value   <- cache.put(0, 0, release.complete(()).void)
@@ -79,7 +79,7 @@ class ExpiringCacheSpec extends AsyncFunSuite with Matchers {
   }
 
   private def notExpireUsedRecords[F[_] : Async] = {
-    ExpiringCache.of[F, Int, Int](ExpiringCache.Config(50.millis)).use { cache =>
+    ExpiringCache.of[F, Int, Int](ExpiringCache.Config[F, Int, Int](50.millis)).use { cache =>
       val touch = for {
         _ <- Temporal[F].sleep(10.millis)
         _ <- cache.get(0)


### PR DESCRIPTION
This PR updates several configuration files and dependencies to align with the latest versions:

- Updated Scala versions to use Scala 3.3.5 and 2.13.16, removing Scala 2.12.18.  
- Updated library versions:
  - scalatest: from 3.2.16 to 3.2.19
  - cats-helper: from 3.6.0 to 3.11.3
  - smetrics: from 2.0.0 to 2.2.0
  - kind-projector: from 0.13.2 to 0.13.3
  - cats-core: from 2.9.0 to 2.13.0
  - cats-effect: from 3.4.11 to 3.5.7
  - bumped sbt version from 1.9.3 to 1.10.10

- Updated plugin versions:
  - sbt-scoverage: from 2.0.8 to 2.3.1
  - sbt-coveralls: from 1.3.9 to 1.3.15
  - sbt-release: from 1.1.0 to 1.4.0

- Drop `sbt-ci-release`-based publishing approach in favour of tag-based approach that's universally used in all other Evolution open-source repositories