### PR TITLE
Update sbt-scalac-opts-plugin to 0.2.0 (cleanup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,16 @@ jobs:
       
       - name: setup SBT
         uses: sbt/setup-sbt@v1
+        with:
+          # sbt 2's disk cache is restored across runs and is not keyed on scoverage's
+          # instrumentation, so a cached compile would be reused without re-emitting coverage data.
+          disk-cache: false
 
       - name: check code ${{ matrix.scala }}
         run: sbt "++${{ matrix.scala }}; clean; check"
 
       - name: build ${{ matrix.scala }}
-        run: sbt "++${{ matrix.scala }}; clean; coverage; test; coverageAggregate"
+        run: sbt "++${{ matrix.scala }}; clean; coverage; testFull; coverageAggregate"
 
       - name: locate coverage report
         id: coverage

--- a/build.sbt
+++ b/build.sbt
@@ -35,9 +35,6 @@ lazy val commonSettings = Seq(
       "-P:kind-projector:underscore-placeholders",
     ),
   ),
-  // -Wnonunit-statement (added in sbt-scalac-opts-plugin 0.1.0) flags ScalaTest's
-  // `x shouldEqual y` used as a non-final statement; too noisy to fix across specs right now.
-  Test / scalacOptions -= "-Wnonunit-statement",
   // Under sbt 2 the compile cache can skip re-creating scoverage's data directory after `clean`.
   // When a module's instrumented code runs inside another module's forked test JVM (before that
   // module's own tests, if any, have run), scoverage.Invoker then crashes writing measurements to


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded continuous integration validation to run the full test suite.
  * Improved build reliability by preventing reuse of instrumented compilation outputs.
  * Removed a compiler warning suppression so non-unit statements are reported during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->