### PR TITLE
revert versionPolicyIgnored for smetrics 3.0.0 (we do not use doobie module)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val commonSettings = Seq(
   versionPolicyIntention := Compatibility.BinaryCompatible,
   versionPolicyIgnored ++= Seq(
     // add libraries here that are known to be binary compatible, like:
-    "com.evolutiongaming" %% "smetrics",
+    // "com.evolutiongaming" %% "smetrics",
   ),
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version-policy tracking configuration.
  * The `smetrics` dependency is no longer excluded from version-policy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->