### PR TITLE
[Security] Submit sbt dependency graph to GitHub

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,9 @@
+name: Dependency graph
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  submit:
+    uses: evolution-gaming/scala-github-actions/.github/workflows/dependency-graph.yml@2a50f1819b6fef2657ba802fd62612b7fc8450f0 # v6.4.0

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: write
+
 jobs:
   submit:
     uses: evolution-gaming/scala-github-actions/.github/workflows/dependency-graph.yml@2a50f1819b6fef2657ba802fd62612b7fc8450f0 # v6.4.0


### PR DESCRIPTION
Adds the shared dependency-graph workflow from scala-github-actions (v6.4.0). GitHub can't parse build.sbt, so without this the repo gets no Dependabot alerts at all. If some modules are unpublished (docs, it-tests), set modules_ignore, see the scala-github-actions README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency graph updates whenever changes are pushed to the master branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->