### PR TITLE
Make cache_size gauge additive across caches sharing a name

### DIFF
--- a/scache/src/main/scala/com/evolution/scache/CacheMetered.scala
+++ b/scache/src/main/scala/com/evolution/scache/CacheMetered.scala
@@ -32,6 +32,7 @@ object CacheMetered {
     }
 
     for {
+      _ <- Resource.onFinalize(metrics.size(0))
       _ <- Schedule(interval, interval)(measureSize)
     } yield {
       abstract class CacheMetered extends Cache.Abstract1[F, K, V]

--- a/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
+++ b/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
@@ -5,16 +5,7 @@ import cats.syntax.all.*
 import cats.{Applicative, Monad}
 import com.evolution.scache.CacheMetrics.Directive
 import com.evolutiongaming.smetrics.MetricsHelper.*
-import com.evolutiongaming.smetrics.{
-  CollectorRegistry,
-  Counter,
-  Gauge,
-  LabelNames,
-  LabelValues,
-  Quantile,
-  Quantiles,
-  Summary,
-}
+import com.evolutiongaming.smetrics.{CollectorRegistry, LabelNames, Quantile, Quantiles}
 
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.FiniteDuration
@@ -101,23 +92,165 @@ object CacheMetrics {
 
   /**
    * Metrics instance per cache name, sharing the collectors. Prefer [[make]]: it tracks the
-   * reported size in a `Ref` and withdraws it when the instance is released, this one has to resort
-   * to an `AtomicInteger` and relies on the caller reporting `0` on release.
+   * reported size in a `Ref` and withdraws it when the instance is released, this one relies on the
+   * caller reporting `0` on release.
    */
   @deprecated("use make", "6.1.0")
   def of[F[_]: Monad](
     collectorRegistry: CollectorRegistry[F],
     prefix: Prefix = Prefix.Default,
   ): Resource[F, Name => CacheMetrics[F]] = {
-    collectors(collectorRegistry, prefix).map { collectors => (name: Name) =>
-      val sizeGauge = collectors.sizeGauge.labels(name)
-      val sizeReported = new AtomicInteger(0)
-      instance(collectors, name) { size =>
-        ().pure[F].flatMap { _ =>
-          val delta = size - sizeReported.getAndSet(size)
-          sizeGauge.inc(delta.toDouble).whenA(delta != 0)
+
+    val getCounter = collectorRegistry.counter(
+      name = s"${ prefix }_get",
+      help = "Get type: hit or miss",
+      labels = LabelNames("name", "type"),
+    )
+
+    val putCounter = collectorRegistry.counter(
+      name = s"${ prefix }_put",
+      help = "Put",
+      labels = LabelNames("name"),
+    )
+
+    val modifyCounter = collectorRegistry.counter(
+      name = s"${ prefix }_modify",
+      help = "Modify, labeled by modification input (entry was present or not), and output (put, keep, or remove)",
+      labels = LabelNames("name", "existing_entry", "result"),
+    )
+
+    val loadResultCounter = collectorRegistry.counter(
+      name = s"${ prefix }_load_result",
+      help = "Load result: success or failure",
+      labels = LabelNames("name", "result"),
+    )
+
+    val quantiles = Quantiles(
+      Quantile(value = 0.9, error = 0.05),
+      Quantile(value = 0.99, error = 0.005),
+    )
+
+    val loadTimeSummary = collectorRegistry.summary(
+      name = s"${ prefix }_load_time",
+      help = s"Load time in seconds",
+      quantiles = quantiles,
+      labels = LabelNames("name", "result"),
+    )
+
+    val sizeGauge = collectorRegistry.gauge(
+      name = s"${ prefix }_size",
+      help = s"Cache size",
+      labels = LabelNames("name"),
+    )
+
+    val lifeTimeSummary = collectorRegistry.summary(
+      name = s"${ prefix }_life_time",
+      help = s"Life time in seconds",
+      quantiles = quantiles,
+      labels = LabelNames("name"),
+    )
+
+    val callSummary = collectorRegistry.summary(
+      name = s"${ prefix }_call_latency",
+      help = "Call latency in seconds",
+      quantiles = quantiles,
+      labels = LabelNames("name", "type"),
+    )
+
+    for {
+      getsCounter <- getCounter
+      putCounter <- putCounter
+      modifyCounter <- modifyCounter
+      loadResultCounter <- loadResultCounter
+      loadTimeSummary <- loadTimeSummary
+      lifeTimeSummary <- lifeTimeSummary
+      sizeGauge <- sizeGauge
+      callSummary <- callSummary
+    } yield {
+      (name: Name) =>
+        val sizeGauge1 = sizeGauge.labels(name)
+
+        val sizeReported = new AtomicInteger(0)
+
+        val hitCounter = getsCounter.labels(name, "hit")
+
+        val missCounter = getsCounter.labels(name, "miss")
+
+        val successCounter = loadResultCounter.labels(name, "success")
+
+        val failureCounter = loadResultCounter.labels(name, "failure")
+
+        val successSummary = loadTimeSummary.labels(name, "success")
+
+        val failureSummary = loadTimeSummary.labels(name, "failure")
+
+        val putCounter1 = putCounter.labels(name)
+
+        val lifeTimeSummary1 = lifeTimeSummary.labels(name)
+
+        val sizeSummary = callSummary.labels(name, "size")
+
+        val keysSummary = callSummary.labels(name, "keys")
+
+        val valuesSummary = callSummary.labels(name, "values")
+
+        val clearSummary = callSummary.labels(name, "clear")
+
+        val foldMapSummary = callSummary.labels(name, "foldMap")
+
+        new CacheMetrics[F] {
+
+          def get(hit: Boolean) = {
+            val counter = if (hit) hitCounter else missCounter
+            counter.inc()
+          }
+
+          def load(time: FiniteDuration, success: Boolean) = {
+            val resultCounter = if (success) successCounter else failureCounter
+            val timeSummary = if (success) successSummary else failureSummary
+            for {
+              _ <- resultCounter.inc()
+              _ <- timeSummary.observe(time.toNanos.nanosToSeconds)
+            } yield {}
+          }
+
+          def life(time: FiniteDuration) = {
+            lifeTimeSummary1.observe(time.toNanos.nanosToSeconds)
+          }
+
+          val put = putCounter1.inc()
+
+          def modify(entryExisted: Boolean, directive: Directive): F[Unit] = {
+            modifyCounter.labels(name, entryExisted.toString, directive.toString).inc()
+          }
+
+          def size(size: Int) = {
+            ().pure[F].flatMap { _ =>
+              val delta = size - sizeReported.getAndSet(size)
+              sizeGauge1.inc(delta.toDouble).whenA(delta != 0)
+            }
+          }
+
+          def size(latency: FiniteDuration) = {
+            sizeSummary.observe(latency.toNanos.nanosToSeconds)
+          }
+
+          def values(latency: FiniteDuration) = {
+            valuesSummary.observe(latency.toNanos.nanosToSeconds)
+          }
+
+          def keys(latency: FiniteDuration) = {
+            keysSummary.observe(latency.toNanos.nanosToSeconds)
+          }
+
+          def clear(latency: FiniteDuration) = {
+            clearSummary.observe(latency.toNanos.nanosToSeconds)
+          }
+
+          def foldMap(latency: FiniteDuration) = {
+            foldMapSummary.observe(latency.toNanos.nanosToSeconds)
+          }
         }
-      }
     }
   }
 
@@ -129,172 +262,160 @@ object CacheMetrics {
     collectorRegistry: CollectorRegistry[F],
     prefix: Prefix = Prefix.Default,
   ): Resource[F, Name => Resource[F, CacheMetrics[F]]] = {
-    collectors(collectorRegistry, prefix).map { collectors => (name: Name) =>
-      val sizeGauge = collectors.sizeGauge.labels(name)
-      Resource.make {
-        Ref[F].of(0).map { sizeReported =>
-          instance(collectors, name) { size =>
-            sizeReported
-              .getAndSet(size)
-              .flatMap { reported => sizeGauge.inc((size - reported).toDouble).whenA(size != reported) }
-          }
-        }
-      } { metrics =>
-        metrics.size(0)
-      }
-    }
-  }
 
-  private final case class Collectors[F[_]](
-    gets: LabelValues.`2`[Counter[F]],
-    puts: LabelValues.`1`[Counter[F]],
-    modifies: LabelValues.`3`[Counter[F]],
-    loadResults: LabelValues.`2`[Counter[F]],
-    loadTimes: LabelValues.`2`[Summary[F]],
-    lifeTimes: LabelValues.`1`[Summary[F]],
-    sizeGauge: LabelValues.`1`[Gauge[F]],
-    calls: LabelValues.`2`[Summary[F]],
-  )
+    val getCounter = collectorRegistry.counter(
+      name = s"${ prefix }_get",
+      help = "Get type: hit or miss",
+      labels = LabelNames("name", "type"),
+    )
 
-  private def collectors[F[_]](
-    collectorRegistry: CollectorRegistry[F],
-    prefix: Prefix,
-  ): Resource[F, Collectors[F]] = {
+    val putCounter = collectorRegistry.counter(
+      name = s"${ prefix }_put",
+      help = "Put",
+      labels = LabelNames("name"),
+    )
+
+    val modifyCounter = collectorRegistry.counter(
+      name = s"${ prefix }_modify",
+      help = "Modify, labeled by modification input (entry was present or not), and output (put, keep, or remove)",
+      labels = LabelNames("name", "existing_entry", "result"),
+    )
+
+    val loadResultCounter = collectorRegistry.counter(
+      name = s"${ prefix }_load_result",
+      help = "Load result: success or failure",
+      labels = LabelNames("name", "result"),
+    )
 
     val quantiles = Quantiles(
       Quantile(value = 0.9, error = 0.05),
       Quantile(value = 0.99, error = 0.005),
     )
 
+    val loadTimeSummary = collectorRegistry.summary(
+      name = s"${ prefix }_load_time",
+      help = s"Load time in seconds",
+      quantiles = quantiles,
+      labels = LabelNames("name", "result"),
+    )
+
+    val sizeGauge = collectorRegistry.gauge(
+      name = s"${ prefix }_size",
+      help = s"Cache size",
+      labels = LabelNames("name"),
+    )
+
+    val lifeTimeSummary = collectorRegistry.summary(
+      name = s"${ prefix }_life_time",
+      help = s"Life time in seconds",
+      quantiles = quantiles,
+      labels = LabelNames("name"),
+    )
+
+    val callSummary = collectorRegistry.summary(
+      name = s"${ prefix }_call_latency",
+      help = "Call latency in seconds",
+      quantiles = quantiles,
+      labels = LabelNames("name", "type"),
+    )
+
     for {
-      gets <- collectorRegistry.counter(
-        name = s"${ prefix }_get",
-        help = "Get type: hit or miss",
-        labels = LabelNames("name", "type"),
-      )
-      puts <- collectorRegistry.counter(
-        name = s"${ prefix }_put",
-        help = "Put",
-        labels = LabelNames("name"),
-      )
-      modifies <- collectorRegistry.counter(
-        name = s"${ prefix }_modify",
-        help = "Modify, labeled by modification input (entry was present or not), and output (put, keep, or remove)",
-        labels = LabelNames("name", "existing_entry", "result"),
-      )
-      loadResults <- collectorRegistry.counter(
-        name = s"${ prefix }_load_result",
-        help = "Load result: success or failure",
-        labels = LabelNames("name", "result"),
-      )
-      loadTimes <- collectorRegistry.summary(
-        name = s"${ prefix }_load_time",
-        help = s"Load time in seconds",
-        quantiles = quantiles,
-        labels = LabelNames("name", "result"),
-      )
-      lifeTimes <- collectorRegistry.summary(
-        name = s"${ prefix }_life_time",
-        help = s"Life time in seconds",
-        quantiles = quantiles,
-        labels = LabelNames("name"),
-      )
-      sizeGauge <- collectorRegistry.gauge(
-        name = s"${ prefix }_size",
-        help = s"Cache size",
-        labels = LabelNames("name"),
-      )
-      calls <- collectorRegistry.summary(
-        name = s"${ prefix }_call_latency",
-        help = "Call latency in seconds",
-        quantiles = quantiles,
-        labels = LabelNames("name", "type"),
-      )
+      getsCounter <- getCounter
+      putCounter <- putCounter
+      modifyCounter <- modifyCounter
+      loadResultCounter <- loadResultCounter
+      loadTimeSummary <- loadTimeSummary
+      lifeTimeSummary <- lifeTimeSummary
+      sizeGauge <- sizeGauge
+      callSummary <- callSummary
     } yield {
-      Collectors(gets, puts, modifies, loadResults, loadTimes, lifeTimes, sizeGauge, calls)
-    }
-  }
+      (name: Name) =>
+        val sizeGauge1 = sizeGauge.labels(name)
 
-  private def instance[F[_]: Monad](
-    collectors: Collectors[F],
-    name: Name,
-  )(
-    reportSize: Int => F[Unit],
-  ): CacheMetrics[F] = {
+        val hitCounter = getsCounter.labels(name, "hit")
 
-    val hitCounter = collectors.gets.labels(name, "hit")
+        val missCounter = getsCounter.labels(name, "miss")
 
-    val missCounter = collectors.gets.labels(name, "miss")
+        val successCounter = loadResultCounter.labels(name, "success")
 
-    val successCounter = collectors.loadResults.labels(name, "success")
+        val failureCounter = loadResultCounter.labels(name, "failure")
 
-    val failureCounter = collectors.loadResults.labels(name, "failure")
+        val successSummary = loadTimeSummary.labels(name, "success")
 
-    val successSummary = collectors.loadTimes.labels(name, "success")
+        val failureSummary = loadTimeSummary.labels(name, "failure")
 
-    val failureSummary = collectors.loadTimes.labels(name, "failure")
+        val putCounter1 = putCounter.labels(name)
 
-    val putCounter = collectors.puts.labels(name)
+        val lifeTimeSummary1 = lifeTimeSummary.labels(name)
 
-    val lifeTimeSummary = collectors.lifeTimes.labels(name)
+        val sizeSummary = callSummary.labels(name, "size")
 
-    val sizeSummary = collectors.calls.labels(name, "size")
+        val keysSummary = callSummary.labels(name, "keys")
 
-    val keysSummary = collectors.calls.labels(name, "keys")
+        val valuesSummary = callSummary.labels(name, "values")
 
-    val valuesSummary = collectors.calls.labels(name, "values")
+        val clearSummary = callSummary.labels(name, "clear")
 
-    val clearSummary = collectors.calls.labels(name, "clear")
+        val foldMapSummary = callSummary.labels(name, "foldMap")
 
-    val foldMapSummary = collectors.calls.labels(name, "foldMap")
+        def metrics(sizeReported: Ref[F, Int]): CacheMetrics[F] = new CacheMetrics[F] {
 
-    new CacheMetrics[F] {
+          def get(hit: Boolean) = {
+            val counter = if (hit) hitCounter else missCounter
+            counter.inc()
+          }
 
-      def get(hit: Boolean) = {
-        val counter = if (hit) hitCounter else missCounter
-        counter.inc()
-      }
+          def load(time: FiniteDuration, success: Boolean) = {
+            val resultCounter = if (success) successCounter else failureCounter
+            val timeSummary = if (success) successSummary else failureSummary
+            for {
+              _ <- resultCounter.inc()
+              _ <- timeSummary.observe(time.toNanos.nanosToSeconds)
+            } yield {}
+          }
 
-      def load(time: FiniteDuration, success: Boolean) = {
-        val resultCounter = if (success) successCounter else failureCounter
-        val timeSummary = if (success) successSummary else failureSummary
-        for {
-          _ <- resultCounter.inc()
-          _ <- timeSummary.observe(time.toNanos.nanosToSeconds)
-        } yield {}
-      }
+          def life(time: FiniteDuration) = {
+            lifeTimeSummary1.observe(time.toNanos.nanosToSeconds)
+          }
 
-      def life(time: FiniteDuration) = {
-        lifeTimeSummary.observe(time.toNanos.nanosToSeconds)
-      }
+          val put = putCounter1.inc()
 
-      val put = putCounter.inc()
+          def modify(entryExisted: Boolean, directive: Directive): F[Unit] = {
+            modifyCounter.labels(name, entryExisted.toString, directive.toString).inc()
+          }
 
-      def modify(entryExisted: Boolean, directive: Directive): F[Unit] = {
-        collectors.modifies.labels(name, entryExisted.toString, directive.toString).inc()
-      }
+          def size(size: Int) = {
+            sizeReported
+              .getAndSet(size)
+              .flatMap { reported => sizeGauge1.inc((size - reported).toDouble).whenA(size != reported) }
+          }
 
-      def size(size: Int) = reportSize(size)
+          def size(latency: FiniteDuration) = {
+            sizeSummary.observe(latency.toNanos.nanosToSeconds)
+          }
 
-      def size(latency: FiniteDuration) = {
-        sizeSummary.observe(latency.toNanos.nanosToSeconds)
-      }
+          def values(latency: FiniteDuration) = {
+            valuesSummary.observe(latency.toNanos.nanosToSeconds)
+          }
 
-      def values(latency: FiniteDuration) = {
-        valuesSummary.observe(latency.toNanos.nanosToSeconds)
-      }
+          def keys(latency: FiniteDuration) = {
+            keysSummary.observe(latency.toNanos.nanosToSeconds)
+          }
 
-      def keys(latency: FiniteDuration) = {
-        keysSummary.observe(latency.toNanos.nanosToSeconds)
-      }
+          def clear(latency: FiniteDuration) = {
+            clearSummary.observe(latency.toNanos.nanosToSeconds)
+          }
 
-      def clear(latency: FiniteDuration) = {
-        clearSummary.observe(latency.toNanos.nanosToSeconds)
-      }
+          def foldMap(latency: FiniteDuration) = {
+            foldMapSummary.observe(latency.toNanos.nanosToSeconds)
+          }
+        }
 
-      def foldMap(latency: FiniteDuration) = {
-        foldMapSummary.observe(latency.toNanos.nanosToSeconds)
-      }
+        Resource.make {
+          Ref[F].of(0).map(metrics)
+        } { metrics =>
+          metrics.size(0)
+        }
     }
   }
 }

--- a/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
+++ b/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
@@ -1,11 +1,20 @@
 package com.evolution.scache
 
-import cats.effect.Resource
+import cats.effect.{Concurrent, Ref, Resource}
 import cats.syntax.all.*
 import cats.{Applicative, Monad}
 import com.evolution.scache.CacheMetrics.Directive
 import com.evolutiongaming.smetrics.MetricsHelper.*
-import com.evolutiongaming.smetrics.{CollectorRegistry, LabelNames, Quantile, Quantiles}
+import com.evolutiongaming.smetrics.{
+  CollectorRegistry,
+  Counter,
+  Gauge,
+  LabelNames,
+  LabelValues,
+  Quantile,
+  Quantiles,
+  Summary,
+}
 
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.FiniteDuration
@@ -90,161 +99,202 @@ object CacheMetrics {
     val Default: Prefix = "cache"
   }
 
+  /**
+   * Metrics instance per cache name, sharing the collectors. Prefer [[make]]: it tracks the
+   * reported size in a `Ref` and withdraws it when the instance is released, this one has to resort
+   * to an `AtomicInteger` and relies on the caller reporting `0` on release.
+   */
+  @deprecated("use make", "6.1.0")
   def of[F[_]: Monad](
     collectorRegistry: CollectorRegistry[F],
     prefix: Prefix = Prefix.Default,
   ): Resource[F, Name => CacheMetrics[F]] = {
+    collectors(collectorRegistry, prefix).map { collectors => (name: Name) =>
+      val sizeGauge = collectors.sizeGauge.labels(name)
+      val sizeReported = new AtomicInteger(0)
+      instance(collectors, name) { size =>
+        ().pure[F].flatMap { _ =>
+          val delta = size - sizeReported.getAndSet(size)
+          sizeGauge.inc(delta.toDouble).whenA(delta != 0)
+        }
+      }
+    }
+  }
 
-    val getCounter = collectorRegistry.counter(
-      name = s"${ prefix }_get",
-      help = "Get type: hit or miss",
-      labels = LabelNames("name", "type"),
-    )
+  /**
+   * Metrics instance per cache name, sharing the collectors. Several caches may report under one
+   * name, each instance adds its size to the shared gauge and takes it back when released.
+   */
+  def make[F[_]: Concurrent](
+    collectorRegistry: CollectorRegistry[F],
+    prefix: Prefix = Prefix.Default,
+  ): Resource[F, Name => Resource[F, CacheMetrics[F]]] = {
+    collectors(collectorRegistry, prefix).map { collectors => (name: Name) =>
+      val sizeGauge = collectors.sizeGauge.labels(name)
+      Resource.make {
+        Ref[F].of(0).map { sizeReported =>
+          instance(collectors, name) { size =>
+            sizeReported
+              .getAndSet(size)
+              .flatMap { reported => sizeGauge.inc((size - reported).toDouble).whenA(size != reported) }
+          }
+        }
+      } { metrics =>
+        metrics.size(0)
+      }
+    }
+  }
 
-    val putCounter = collectorRegistry.counter(
-      name = s"${ prefix }_put",
-      help = "Put",
-      labels = LabelNames("name"),
-    )
+  private final case class Collectors[F[_]](
+    gets: LabelValues.`2`[Counter[F]],
+    puts: LabelValues.`1`[Counter[F]],
+    modifies: LabelValues.`3`[Counter[F]],
+    loadResults: LabelValues.`2`[Counter[F]],
+    loadTimes: LabelValues.`2`[Summary[F]],
+    lifeTimes: LabelValues.`1`[Summary[F]],
+    sizeGauge: LabelValues.`1`[Gauge[F]],
+    calls: LabelValues.`2`[Summary[F]],
+  )
 
-    val modifyCounter = collectorRegistry.counter(
-      name = s"${ prefix }_modify",
-      help = "Modify, labeled by modification input (entry was present or not), and output (put, keep, or remove)",
-      labels = LabelNames("name", "existing_entry", "result"),
-    )
-
-    val loadResultCounter = collectorRegistry.counter(
-      name = s"${ prefix }_load_result",
-      help = "Load result: success or failure",
-      labels = LabelNames("name", "result"),
-    )
+  private def collectors[F[_]](
+    collectorRegistry: CollectorRegistry[F],
+    prefix: Prefix,
+  ): Resource[F, Collectors[F]] = {
 
     val quantiles = Quantiles(
       Quantile(value = 0.9, error = 0.05),
       Quantile(value = 0.99, error = 0.005),
     )
 
-    val loadTimeSummary = collectorRegistry.summary(
-      name = s"${ prefix }_load_time",
-      help = s"Load time in seconds",
-      quantiles = quantiles,
-      labels = LabelNames("name", "result"),
-    )
-
-    val sizeGauge = collectorRegistry.gauge(
-      name = s"${ prefix }_size",
-      help = s"Cache size",
-      labels = LabelNames("name"),
-    )
-
-    val lifeTimeSummary = collectorRegistry.summary(
-      name = s"${ prefix }_life_time",
-      help = s"Life time in seconds",
-      quantiles = quantiles,
-      labels = LabelNames("name"),
-    )
-
-    val callSummary = collectorRegistry.summary(
-      name = s"${ prefix }_call_latency",
-      help = "Call latency in seconds",
-      quantiles = quantiles,
-      labels = LabelNames("name", "type"),
-    )
-
     for {
-      getsCounter <- getCounter
-      putCounter <- putCounter
-      modifyCounter <- modifyCounter
-      loadResultCounter <- loadResultCounter
-      loadTimeSummary <- loadTimeSummary
-      lifeTimeSummary <- lifeTimeSummary
-      sizeGauge <- sizeGauge
-      callSummary <- callSummary
+      gets <- collectorRegistry.counter(
+        name = s"${ prefix }_get",
+        help = "Get type: hit or miss",
+        labels = LabelNames("name", "type"),
+      )
+      puts <- collectorRegistry.counter(
+        name = s"${ prefix }_put",
+        help = "Put",
+        labels = LabelNames("name"),
+      )
+      modifies <- collectorRegistry.counter(
+        name = s"${ prefix }_modify",
+        help = "Modify, labeled by modification input (entry was present or not), and output (put, keep, or remove)",
+        labels = LabelNames("name", "existing_entry", "result"),
+      )
+      loadResults <- collectorRegistry.counter(
+        name = s"${ prefix }_load_result",
+        help = "Load result: success or failure",
+        labels = LabelNames("name", "result"),
+      )
+      loadTimes <- collectorRegistry.summary(
+        name = s"${ prefix }_load_time",
+        help = s"Load time in seconds",
+        quantiles = quantiles,
+        labels = LabelNames("name", "result"),
+      )
+      lifeTimes <- collectorRegistry.summary(
+        name = s"${ prefix }_life_time",
+        help = s"Life time in seconds",
+        quantiles = quantiles,
+        labels = LabelNames("name"),
+      )
+      sizeGauge <- collectorRegistry.gauge(
+        name = s"${ prefix }_size",
+        help = s"Cache size",
+        labels = LabelNames("name"),
+      )
+      calls <- collectorRegistry.summary(
+        name = s"${ prefix }_call_latency",
+        help = "Call latency in seconds",
+        quantiles = quantiles,
+        labels = LabelNames("name", "type"),
+      )
     } yield {
-      (name: Name) =>
-        val hitCounter = getsCounter.labels(name, "hit")
+      Collectors(gets, puts, modifies, loadResults, loadTimes, lifeTimes, sizeGauge, calls)
+    }
+  }
 
-        val missCounter = getsCounter.labels(name, "miss")
+  private def instance[F[_]: Monad](
+    collectors: Collectors[F],
+    name: Name,
+  )(
+    reportSize: Int => F[Unit],
+  ): CacheMetrics[F] = {
 
-        val successCounter = loadResultCounter.labels(name, "success")
+    val hitCounter = collectors.gets.labels(name, "hit")
 
-        val failureCounter = loadResultCounter.labels(name, "failure")
+    val missCounter = collectors.gets.labels(name, "miss")
 
-        val successSummary = loadTimeSummary.labels(name, "success")
+    val successCounter = collectors.loadResults.labels(name, "success")
 
-        val failureSummary = loadTimeSummary.labels(name, "failure")
+    val failureCounter = collectors.loadResults.labels(name, "failure")
 
-        val putCounter1 = putCounter.labels(name)
+    val successSummary = collectors.loadTimes.labels(name, "success")
 
-        val lifeTimeSummary1 = lifeTimeSummary.labels(name)
+    val failureSummary = collectors.loadTimes.labels(name, "failure")
 
-        val sizeSummary = callSummary.labels(name, "size")
+    val putCounter = collectors.puts.labels(name)
 
-        val keysSummary = callSummary.labels(name, "keys")
+    val lifeTimeSummary = collectors.lifeTimes.labels(name)
 
-        val valuesSummary = callSummary.labels(name, "values")
+    val sizeSummary = collectors.calls.labels(name, "size")
 
-        val clearSummary = callSummary.labels(name, "clear")
+    val keysSummary = collectors.calls.labels(name, "keys")
 
-        val foldMapSummary = callSummary.labels(name, "foldMap")
+    val valuesSummary = collectors.calls.labels(name, "values")
 
-        val sizeGauge1 = sizeGauge.labels(name)
+    val clearSummary = collectors.calls.labels(name, "clear")
 
-        val sizeReported = new AtomicInteger(0)
+    val foldMapSummary = collectors.calls.labels(name, "foldMap")
 
-        new CacheMetrics[F] {
+    new CacheMetrics[F] {
 
-          def get(hit: Boolean) = {
-            val counter = if (hit) hitCounter else missCounter
-            counter.inc()
-          }
+      def get(hit: Boolean) = {
+        val counter = if (hit) hitCounter else missCounter
+        counter.inc()
+      }
 
-          def load(time: FiniteDuration, success: Boolean) = {
-            val resultCounter = if (success) successCounter else failureCounter
-            val timeSummary = if (success) successSummary else failureSummary
-            for {
-              _ <- resultCounter.inc()
-              _ <- timeSummary.observe(time.toNanos.nanosToSeconds)
-            } yield {}
-          }
+      def load(time: FiniteDuration, success: Boolean) = {
+        val resultCounter = if (success) successCounter else failureCounter
+        val timeSummary = if (success) successSummary else failureSummary
+        for {
+          _ <- resultCounter.inc()
+          _ <- timeSummary.observe(time.toNanos.nanosToSeconds)
+        } yield {}
+      }
 
-          def life(time: FiniteDuration) = {
-            lifeTimeSummary1.observe(time.toNanos.nanosToSeconds)
-          }
+      def life(time: FiniteDuration) = {
+        lifeTimeSummary.observe(time.toNanos.nanosToSeconds)
+      }
 
-          val put = putCounter1.inc()
+      val put = putCounter.inc()
 
-          def modify(entryExisted: Boolean, directive: Directive): F[Unit] = {
-            modifyCounter.labels(name, entryExisted.toString, directive.toString).inc()
-          }
+      def modify(entryExisted: Boolean, directive: Directive): F[Unit] = {
+        collectors.modifies.labels(name, entryExisted.toString, directive.toString).inc()
+      }
 
-          def size(size: Int) = {
-            ().pure[F].flatMap { _ =>
-              val delta = size - sizeReported.getAndSet(size)
-              sizeGauge1.inc(delta.toDouble).whenA(delta != 0)
-            }
-          }
+      def size(size: Int) = reportSize(size)
 
-          def size(latency: FiniteDuration) = {
-            sizeSummary.observe(latency.toNanos.nanosToSeconds)
-          }
+      def size(latency: FiniteDuration) = {
+        sizeSummary.observe(latency.toNanos.nanosToSeconds)
+      }
 
-          def values(latency: FiniteDuration) = {
-            valuesSummary.observe(latency.toNanos.nanosToSeconds)
-          }
+      def values(latency: FiniteDuration) = {
+        valuesSummary.observe(latency.toNanos.nanosToSeconds)
+      }
 
-          def keys(latency: FiniteDuration) = {
-            keysSummary.observe(latency.toNanos.nanosToSeconds)
-          }
+      def keys(latency: FiniteDuration) = {
+        keysSummary.observe(latency.toNanos.nanosToSeconds)
+      }
 
-          def clear(latency: FiniteDuration) = {
-            clearSummary.observe(latency.toNanos.nanosToSeconds)
-          }
+      def clear(latency: FiniteDuration) = {
+        clearSummary.observe(latency.toNanos.nanosToSeconds)
+      }
 
-          def foldMap(latency: FiniteDuration) = {
-            foldMapSummary.observe(latency.toNanos.nanosToSeconds)
-          }
-        }
+      def foldMap(latency: FiniteDuration) = {
+        foldMapSummary.observe(latency.toNanos.nanosToSeconds)
+      }
     }
   }
 }

--- a/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
+++ b/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
@@ -7,6 +7,7 @@ import com.evolution.scache.CacheMetrics.Directive
 import com.evolutiongaming.smetrics.MetricsHelper.*
 import com.evolutiongaming.smetrics.{CollectorRegistry, LabelNames, Quantile, Quantiles}
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.FiniteDuration
 
 trait CacheMetrics[F[_]] {
@@ -21,6 +22,11 @@ trait CacheMetrics[F[_]] {
 
   def modify(entryExisted: Boolean, directive: Directive): F[Unit]
 
+  /**
+   * Reports the current number of entries. Several caches may report under one name, hence the
+   * reported value must be added to the values of the others rather than overwrite them, and a
+   * cache being released must report `0` to withdraw its share.
+   */
   def size(size: Int): F[Unit]
 
   def size(latency: FiniteDuration): F[Unit]
@@ -182,6 +188,10 @@ object CacheMetrics {
 
         val foldMapSummary = callSummary.labels(name, "foldMap")
 
+        val sizeGauge1 = sizeGauge.labels(name)
+
+        val sizeReported = new AtomicInteger(0)
+
         new CacheMetrics[F] {
 
           def get(hit: Boolean) = {
@@ -209,7 +219,10 @@ object CacheMetrics {
           }
 
           def size(size: Int) = {
-            sizeGauge.labels(name).set(size.toDouble)
+            ().pure[F].flatMap { _ =>
+              val delta = size - sizeReported.getAndSet(size)
+              if (delta == 0) ().pure[F] else sizeGauge1.inc(delta.toDouble)
+            }
           }
 
           def size(latency: FiniteDuration) = {

--- a/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
+++ b/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
@@ -221,7 +221,7 @@ object CacheMetrics {
           def size(size: Int) = {
             ().pure[F].flatMap { _ =>
               val delta = size - sizeReported.getAndSet(size)
-              if (delta == 0) ().pure[F] else sizeGauge1.inc(delta.toDouble)
+              sizeGauge1.inc(delta.toDouble).whenA(delta != 0)
             }
           }
 

--- a/scache/src/test/scala/com/evolution/scache/CacheMeteredSpec.scala
+++ b/scache/src/test/scala/com/evolution/scache/CacheMeteredSpec.scala
@@ -1,0 +1,43 @@
+package com.evolution.scache
+
+import cats.effect.{IO, Ref}
+import com.evolution.scache.IOSuite.*
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.*
+
+class CacheMeteredSpec extends AsyncFunSuite with Matchers {
+
+  private def sizeRecorder(sizes: Ref[IO, List[Int]]): CacheMetrics[IO] = new CacheMetrics[IO] {
+    def get(hit: Boolean): IO[Unit] = IO.unit
+    def load(time: FiniteDuration, success: Boolean): IO[Unit] = IO.unit
+    def life(time: FiniteDuration): IO[Unit] = IO.unit
+    def put: IO[Unit] = IO.unit
+    def modify(entryExisted: Boolean, directive: CacheMetrics.Directive): IO[Unit] = IO.unit
+    def size(size: Int): IO[Unit] = sizes.update(size :: _)
+    def size(latency: FiniteDuration): IO[Unit] = IO.unit
+    def values(latency: FiniteDuration): IO[Unit] = IO.unit
+    def keys(latency: FiniteDuration): IO[Unit] = IO.unit
+    def clear(latency: FiniteDuration): IO[Unit] = IO.unit
+    def foldMap(latency: FiniteDuration): IO[Unit] = IO.unit
+  }
+
+  test("size is reported on schedule and withdrawn on release") {
+    val result = for {
+      sizes <- Ref.of[IO, List[Int]](Nil)
+      cache = Cache.loading[IO, Int, Int].flatMap { cache => CacheMetered(cache, sizeRecorder(sizes), 10.millis) }
+      _ <- cache.use { cache =>
+        for {
+          _ <- cache.put(0, 0)
+          _ <- cache.put(1, 1)
+          _ <- (IO.sleep(5.millis) *> sizes.get).iterateUntil(_.contains(2)).timeout(1.second)
+        } yield {}
+      }
+      sizes <- sizes.get
+      _ = sizes.head shouldEqual 0
+      _ = sizes should contain(2)
+    } yield {}
+    result.run()
+  }
+}

--- a/scache/src/test/scala/com/evolution/scache/CacheMetricsSpec.scala
+++ b/scache/src/test/scala/com/evolution/scache/CacheMetricsSpec.scala
@@ -1,0 +1,55 @@
+package com.evolution.scache
+
+import cats.effect.{IO, Ref}
+import cats.syntax.all.*
+import com.evolution.scache.IOSuite.*
+import com.evolutiongaming.smetrics.{CollectorRegistry, Counter, Gauge, Histogram, Info, Summary}
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class CacheMetricsSpec extends AsyncFunSuite with Matchers {
+
+  private def registry(gauge: Ref[IO, Double]): CollectorRegistry[IO] = {
+    val gauge1 = new Gauge[IO] {
+      def inc(value: Double): IO[Unit] = gauge.update(_ + value)
+      def dec(value: Double): IO[Unit] = gauge.update(_ - value)
+      def set(value: Double): IO[Unit] = gauge.set(value)
+    }
+    CollectorRegistry.const[IO](
+      gauge1.pure[IO],
+      Counter.empty[IO].pure[IO],
+      Summary.empty[IO].pure[IO],
+      Histogram.empty[IO].pure[IO],
+      Info.empty[IO].pure[IO],
+    )
+  }
+
+  test("size sums over caches reporting under the same name") {
+    val result = for {
+      gauge <- Ref.of[IO, Double](0)
+      _ <- CacheMetrics.of(registry(gauge)).use { metricsOf =>
+        val a = metricsOf("name")
+        val b = metricsOf("name")
+        for {
+          _ <- a.size(10)
+          _ <- b.size(5)
+          v <- gauge.get
+          _ = v shouldEqual 15
+          _ <- a.size(7)
+          v <- gauge.get
+          _ = v shouldEqual 12
+          _ <- a.size(7)
+          v <- gauge.get
+          _ = v shouldEqual 12
+          _ <- b.size(0)
+          v <- gauge.get
+          _ = v shouldEqual 7
+          _ <- a.size(0)
+          v <- gauge.get
+          _ = v shouldEqual 0
+        } yield {}
+      }
+    } yield {}
+    result.run()
+  }
+}

--- a/scache/src/test/scala/com/evolution/scache/CacheMetricsSpec.scala
+++ b/scache/src/test/scala/com/evolution/scache/CacheMetricsSpec.scala
@@ -7,6 +7,8 @@ import com.evolutiongaming.smetrics.{CollectorRegistry, Counter, Gauge, Histogra
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import scala.annotation.nowarn
+
 class CacheMetricsSpec extends AsyncFunSuite with Matchers {
 
   private def registry(gauge: Ref[IO, Double]): CollectorRegistry[IO] = {
@@ -24,31 +26,55 @@ class CacheMetricsSpec extends AsyncFunSuite with Matchers {
     )
   }
 
-  test("size sums over caches reporting under the same name") {
+  private def expect(gauge: Ref[IO, Double], value: Double): IO[Unit] =
+    gauge.get.map { _ shouldEqual value }.void
+
+  test("of: size sums over caches reporting under the same name") {
     val result = for {
       gauge <- Ref.of[IO, Double](0)
-      _ <- CacheMetrics.of(registry(gauge)).use { metricsOf =>
+      _ <- (CacheMetrics.of(registry(gauge)): @nowarn("cat=deprecation")).use { metricsOf =>
         val a = metricsOf("name")
         val b = metricsOf("name")
         for {
           _ <- a.size(10)
           _ <- b.size(5)
-          v <- gauge.get
-          _ = v shouldEqual 15
+          _ <- expect(gauge, 15)
           _ <- a.size(7)
-          v <- gauge.get
-          _ = v shouldEqual 12
+          _ <- expect(gauge, 12)
           _ <- a.size(7)
-          v <- gauge.get
-          _ = v shouldEqual 12
+          _ <- expect(gauge, 12)
           _ <- b.size(0)
-          v <- gauge.get
-          _ = v shouldEqual 7
+          _ <- expect(gauge, 7)
           _ <- a.size(0)
-          v <- gauge.get
-          _ = v shouldEqual 0
+          _ <- expect(gauge, 0)
         } yield {}
       }
+    } yield {}
+    result.run()
+  }
+
+  test("make: size sums over caches reporting under the same name and is withdrawn on release") {
+    val result = for {
+      gauge <- Ref.of[IO, Double](0)
+      _ <- CacheMetrics.make(registry(gauge)).use { metricsOf =>
+        metricsOf("name").use { a =>
+          for {
+            _ <- a.size(10)
+            _ <- metricsOf("name").use { b =>
+              for {
+                _ <- b.size(5)
+                _ <- expect(gauge, 15)
+                _ <- a.size(7)
+                _ <- expect(gauge, 12)
+                _ <- a.size(7)
+                _ <- expect(gauge, 12)
+              } yield {}
+            }
+            _ <- expect(gauge, 7)
+          } yield {}
+        }
+      }
+      _ <- expect(gauge, 0)
     } yield {}
     result.run()
   }

--- a/scache/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/scache/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -99,7 +99,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.get(0)
         _ <- IO { a shouldEqual none[Int] }
-        _ <- metrics.expect(metrics.expectedGet(hit = false) -> 1)
+        _ <- metrics.expect(metrics.expectedGet(hit = false) -> 1, metrics.expectedSize(0) -> 1)
       } yield {}
       result.run()
     }
@@ -124,7 +124,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.getOrElse(0, 1.pure[IO])
         _ <- IO { a shouldEqual 1 }
-        _ <- metrics.expect(metrics.expectedGet(hit = false) -> 1)
+        _ <- metrics.expect(metrics.expectedGet(hit = false) -> 1, metrics.expectedSize(0) -> 1)
       } yield {}
       result.run()
     }
@@ -155,7 +155,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.put(0, 0).flatten
         _ <- IO { a shouldEqual none[Int] }
-        _ <- metrics.expect(metrics.expectedPut -> 1)
+        _ <- metrics.expect(metrics.expectedPut -> 1, metrics.expectedSize(0) -> 1)
       } yield {}
       result.run()
     }
@@ -193,7 +193,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.put(0, 0, ().pure[IO]).flatten.attempt
         _ <- IO { a shouldEqual CacheReleasedError.asLeft }
-        _ <- metrics.expect()
+        _ <- metrics.expect(metrics.expectedSize(0) -> 1)
       } yield {}
       result.run()
     }
@@ -275,6 +275,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         a <- cache.size
         _ <- IO { a shouldEqual 0 }
         _ <- metrics.expect(
+          metrics.expectedSize(0) -> 1,
           metrics.expectedPut -> 1,
           metrics.expectedLife -> 1,
           metrics.expectedSize -> 1,
@@ -304,7 +305,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.remove(0).flatten
         _ <- IO { a shouldEqual none }
-        _ <- metrics.expect()
+        _ <- metrics.expect(metrics.expectedSize(0) -> 1)
       } yield {}
       result.run()
     }
@@ -331,7 +332,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
       val result = for {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         _ <- cache.clear.flatten
-        _ <- metrics.expect(metrics.expectedClear -> 1)
+        _ <- metrics.expect(metrics.expectedClear -> 1, metrics.expectedSize(0) -> 1)
       } yield {}
       result.run()
     }
@@ -424,6 +425,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         a <- cache.getOrUpdate(0)(1.pure[IO])
         _ <- IO { a shouldEqual 1 }
         _ <- metrics.expect(
+          metrics.expectedSize(0) -> 1,
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedLoad(success = true) -> 1,
         )
@@ -565,6 +567,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         a <- cache.getOrUpdate1(0)((1, 1, none[IO[Unit]]).pure[IO])
         _ <- IO { a shouldEqual 1.asLeft }
         _ <- metrics.expect(
+          metrics.expectedSize(0) -> 1,
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedLoad(success = true) -> 1,
         )
@@ -578,6 +581,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         a <- cache.getOrUpdate1(0)((1, 1, IO.unit.some).pure[IO]).attempt
         _ <- IO { a shouldEqual CacheReleasedError.asLeft }
         _ <- metrics.expect(
+          metrics.expectedSize(0) -> 1,
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedLoad(success = false) -> 1,
         )
@@ -591,6 +595,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         a <- cache.getOrUpdateOpt1(0)((1, 1, none[IO[Unit]]).some.pure[IO])
         _ <- IO { a shouldEqual 1.asLeft.some }
         _ <- metrics.expect(
+          metrics.expectedSize(0) -> 1,
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedLoad(success = true) -> 1,
         )
@@ -604,6 +609,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         a <- cache.getOrUpdateOpt1(0)((1, 1, IO.unit.some).some.pure[IO]).attempt
         _ <- IO { a shouldEqual CacheReleasedError.asLeft }
         _ <- metrics.expect(
+          metrics.expectedSize(0) -> 1,
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedLoad(success = false) -> 1,
         )

--- a/scache/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/scache/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -52,7 +52,9 @@ class CacheSpec extends AsyncFunSuite with Matchers {
       for {
         value <- cache.get(0)
         _ <- IO { value shouldEqual none[Int] }
-        _ <- metrics.expect(metrics.expectedGet(hit = false) -> 1)
+        _ <- metrics.expect(
+          metrics.expectedGet(hit = false) -> 1,
+        )
       } yield {}
     }
 
@@ -99,7 +101,10 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.get(0)
         _ <- IO { a shouldEqual none[Int] }
-        _ <- metrics.expect(metrics.expectedGet(hit = false) -> 1, metrics.expectedSize(0) -> 1)
+        _ <- metrics.expect(
+          metrics.expectedGet(hit = false) -> 1,
+          metrics.expectedSize(0) -> 1,
+        )
       } yield {}
       result.run()
     }
@@ -124,7 +129,10 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.getOrElse(0, 1.pure[IO])
         _ <- IO { a shouldEqual 1 }
-        _ <- metrics.expect(metrics.expectedGet(hit = false) -> 1, metrics.expectedSize(0) -> 1)
+        _ <- metrics.expect(
+          metrics.expectedGet(hit = false) -> 1,
+          metrics.expectedSize(0) -> 1,
+        )
       } yield {}
       result.run()
     }
@@ -155,7 +163,10 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.put(0, 0).flatten
         _ <- IO { a shouldEqual none[Int] }
-        _ <- metrics.expect(metrics.expectedPut -> 1, metrics.expectedSize(0) -> 1)
+        _ <- metrics.expect(
+          metrics.expectedPut -> 1,
+          metrics.expectedSize(0) -> 1,
+        )
       } yield {}
       result.run()
     }
@@ -193,7 +204,9 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.put(0, 0, ().pure[IO]).flatten.attempt
         _ <- IO { a shouldEqual CacheReleasedError.asLeft }
-        _ <- metrics.expect(metrics.expectedSize(0) -> 1)
+        _ <- metrics.expect(
+          metrics.expectedSize(0) -> 1,
+        )
       } yield {}
       result.run()
     }
@@ -305,7 +318,9 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         a <- cache.remove(0).flatten
         _ <- IO { a shouldEqual none }
-        _ <- metrics.expect(metrics.expectedSize(0) -> 1)
+        _ <- metrics.expect(
+          metrics.expectedSize(0) -> 1,
+        )
       } yield {}
       result.run()
     }
@@ -332,7 +347,10 @@ class CacheSpec extends AsyncFunSuite with Matchers {
       val result = for {
         (cache, metrics) <- cacheAndMetrics.use { _.pure[IO] }
         _ <- cache.clear.flatten
-        _ <- metrics.expect(metrics.expectedClear -> 1, metrics.expectedSize(0) -> 1)
+        _ <- metrics.expect(
+          metrics.expectedClear -> 1,
+          metrics.expectedSize(0) -> 1,
+        )
       } yield {}
       result.run()
     }
@@ -1111,7 +1129,9 @@ class CacheSpec extends AsyncFunSuite with Matchers {
             _ <- IO { result shouldEqual none }
             _ <- deferred.complete(0)
             _ <- fiber.joinWithNever
-            _ <- metrics.expect(metrics.expectedGet(hit = false) -> 2)
+            _ <- metrics.expect(
+              metrics.expectedGet(hit = false) -> 2,
+            )
           } yield {}
         }
         .run()


### PR DESCRIPTION
Every cache reporting under the same name used to overwrite the `cache_size` gauge, so it showed whichever reported last. Each cache now adds its delta and withdraws its share on release. `cache_size` will show the true sum for a name, so dashboards will step up after upgrading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a resource-managed metrics factory for aggregating cache sizes across instances that share a metric name.
  * Cache size contributions are automatically withdrawn when caches or metrics resources are released.

* **Bug Fixes**
  * Cache size metrics now reset to zero after cache resource finalization.

* **Documentation**
  * Documented that size metrics accumulate contributions rather than overwrite existing values.
  * Marked the existing metrics factory as deprecated in favor of the resource-managed factory.

* **Tests**
  * Added coverage for aggregation, scheduled reporting, and release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->