### PR TITLE
Report cancelled loads in load metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,6 +114,8 @@ lazy val scache = (project in file("scache"))
       ProblemFilters.exclude[MissingClassProblem]("com.evolution.scache.LoadingCache$EntryRefs$"),
       ProblemFilters.exclude[MissingClassProblem]("com.evolution.scache.ExpiringCache$MapOps"),
       ProblemFilters.exclude[MissingClassProblem]("com.evolution.scache.ExpiringCache$MapOps$"),
+      // CacheMetrics.load takes LoadResult, reviewed in https://github.com/evolution-gaming/scache/issues/386
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.evolution.scache.CacheMetrics.load"),
     ),
     libraryDependencies ++= Seq(
       Cats.core,

--- a/scache/src/main/scala/com/evolution/scache/CacheMetered.scala
+++ b/scache/src/main/scala/com/evolution/scache/CacheMetered.scala
@@ -1,9 +1,11 @@
 package com.evolution.scache
 
+import cats.effect.implicits.*
 import cats.effect.{Resource, Temporal}
 import cats.kernel.CommutativeMonoid
 import cats.syntax.all.*
 import com.evolution.scache.Cache.Directive
+import com.evolution.scache.CacheMetrics.LoadResult
 import com.evolutiongaming.catshelper.{MeasureDuration, Schedule}
 
 import scala.concurrent.duration.*
@@ -66,13 +68,13 @@ object CacheMetered {
               for {
                 _ <- metrics.get(false)
                 start <- MeasureDuration[F].start
-                value <- value.attempt
+                value <- value.attempt.onCancel { start.flatMap { metrics.load(_, LoadResult.Cancelled) } }
                 duration <- start
-                loadSucceed = value match {
-                  case Right(_) | Left(CacheOpsCompat.NoneError) => true
-                  case Left(_) => false
+                result = value match {
+                  case Right(_) | Left(CacheOpsCompat.NoneError) => LoadResult.Success
+                  case Left(_) => LoadResult.Failure
                 }
-                _ <- metrics.load(duration, loadSucceed)
+                _ <- metrics.load(duration, result)
                 value <- value.liftTo[F]
               } yield {
                 val (a, v, release) = value

--- a/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
+++ b/scache/src/main/scala/com/evolution/scache/CacheMetrics.scala
@@ -3,7 +3,7 @@ package com.evolution.scache
 import cats.effect.Resource
 import cats.syntax.all.*
 import cats.{Applicative, Monad}
-import com.evolution.scache.CacheMetrics.Directive
+import com.evolution.scache.CacheMetrics.{Directive, LoadResult}
 import com.evolutiongaming.smetrics.MetricsHelper.*
 import com.evolutiongaming.smetrics.{CollectorRegistry, LabelNames, Quantile, Quantiles}
 
@@ -13,7 +13,11 @@ trait CacheMetrics[F[_]] {
 
   def get(hit: Boolean): F[Unit]
 
-  def load(time: FiniteDuration, success: Boolean): F[Unit]
+  def load(time: FiniteDuration, result: LoadResult): F[Unit]
+
+  @deprecated("use load(time, LoadResult)", "7.0.0")
+  def load(time: FiniteDuration, success: Boolean): F[Unit] =
+    load(time, if (success) LoadResult.Success else LoadResult.Failure)
 
   def life(time: FiniteDuration): F[Unit]
 
@@ -42,7 +46,7 @@ object CacheMetrics {
 
     def get(hit: Boolean) = unit
 
-    def load(time: FiniteDuration, success: Boolean) = unit
+    def load(time: FiniteDuration, result: LoadResult) = unit
 
     def life(time: FiniteDuration) = unit
 
@@ -74,6 +78,25 @@ object CacheMetrics {
     case object Put extends Directive
     case object Ignore extends Directive
     case object Remove extends Directive
+  }
+
+  /**
+   * Outcome of a value computation started by `getOrUpdate`: it produced a value, failed, or was
+   * cancelled before doing either.
+   */
+  sealed trait LoadResult {
+    override def toString: Prefix = this match {
+      case LoadResult.Success => "success"
+      case LoadResult.Failure => "failure"
+      case LoadResult.Cancelled => "cancelled"
+    }
+  }
+  object LoadResult {
+    case object Success extends LoadResult
+    case object Failure extends LoadResult
+    case object Cancelled extends LoadResult
+
+    val values: List[LoadResult] = List(Success, Failure, Cancelled)
   }
 
   type Name = String
@@ -109,7 +132,7 @@ object CacheMetrics {
 
     val loadResultCounter = collectorRegistry.counter(
       name = s"${ prefix }_load_result",
-      help = "Load result: success or failure",
+      help = "Load result: success, failure or cancelled",
       labels = LabelNames("name", "result"),
     )
 
@@ -160,13 +183,13 @@ object CacheMetrics {
 
         val missCounter = getsCounter.labels(name, "miss")
 
-        val successCounter = loadResultCounter.labels(name, "success")
+        val loadCounters = LoadResult.values.map { result =>
+          (result, loadResultCounter.labels(name, result.toString))
+        }.toMap
 
-        val failureCounter = loadResultCounter.labels(name, "failure")
-
-        val successSummary = loadTimeSummary.labels(name, "success")
-
-        val failureSummary = loadTimeSummary.labels(name, "failure")
+        val loadSummaries = LoadResult.values.map { result =>
+          (result, loadTimeSummary.labels(name, result.toString))
+        }.toMap
 
         val putCounter1 = putCounter.labels(name)
 
@@ -189,12 +212,10 @@ object CacheMetrics {
             counter.inc()
           }
 
-          def load(time: FiniteDuration, success: Boolean) = {
-            val resultCounter = if (success) successCounter else failureCounter
-            val timeSummary = if (success) successSummary else failureSummary
+          def load(time: FiniteDuration, result: LoadResult) = {
             for {
-              _ <- resultCounter.inc()
-              _ <- timeSummary.observe(time.toNanos.nanosToSeconds)
+              _ <- loadCounters(result).inc()
+              _ <- loadSummaries(result).observe(time.toNanos.nanosToSeconds)
             } yield {}
           }
 

--- a/scache/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/scache/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -91,7 +91,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
           metrics.expectedGet(hit = true) -> 3,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
           metrics.expectedPut -> 1,
         )
       } yield {}
@@ -371,7 +371,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
           metrics.expectedPut -> 2,
           metrics.expectedLife -> 4,
           metrics.expectedClear -> 1,
-          metrics.expectedLoad(success = true) -> 2,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 2,
         )
       } yield {}
     }
@@ -415,7 +415,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value1 shouldEqual 0 }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
           metrics.expectedGet(hit = true) -> 1,
         )
       } yield {}
@@ -428,7 +428,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { a shouldEqual 1 }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
       result.run()
@@ -445,7 +445,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual 0.some }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedLoad(success = true) -> 2,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 2,
         )
       } yield {}
     }
@@ -480,7 +480,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
           metrics.expectedGet(hit = false) -> 2,
           metrics.expectedLife -> 2,
           metrics.expectedClear -> 1,
-          metrics.expectedLoad(success = true) -> 2,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 2,
         )
       } yield {}
     }
@@ -505,7 +505,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedGet(hit = true) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
     }
@@ -536,7 +536,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- released.complete(())
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedLoad(success = true) -> 2,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 2,
           metrics.expectedGet(hit = true) -> 1,
         )
       } yield {}
@@ -553,7 +553,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual 1.asLeft.some }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedLoad(success = true) -> 2,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 2,
         )
       } yield {}
     }
@@ -565,7 +565,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { a shouldEqual 1.asLeft }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
       result.run()
@@ -578,7 +578,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { a shouldEqual CacheReleasedError.asLeft }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
-          metrics.expectedLoad(success = false) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
         )
       } yield {}
       result.run()
@@ -591,7 +591,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { a shouldEqual 1.asLeft.some }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
       result.run()
@@ -604,7 +604,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { a shouldEqual CacheReleasedError.asLeft }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
-          metrics.expectedLoad(success = false) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
         )
       } yield {}
       result.run()
@@ -624,7 +624,8 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
           metrics.expectedGet(hit = true) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Cancelled) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
     }
@@ -643,7 +644,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual 1.some }
         _ <- metrics.expect(
           metrics.expectedGet(hit = true) -> 2,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedPut -> 1,
           metrics.expectedLife -> 1,
@@ -667,7 +668,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual 1.some }
         _ <- metrics.expect(
           metrics.expectedGet(hit = true) -> 2,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedPut -> 1,
           metrics.expectedLife -> 1,
@@ -726,7 +727,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedPut -> 1,
-          metrics.expectedLoad(success = false) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
           metrics.expectedGet(hit = true) -> 2,
         )
       } yield {}
@@ -747,7 +748,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedPut -> 1,
-          metrics.expectedLoad(success = false) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
           metrics.expectedGet(hit = true) -> 2,
         )
       } yield {}
@@ -765,7 +766,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual 0.some }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
           metrics.expectedGet(hit = true) -> 1,
         )
       } yield {}
@@ -785,7 +786,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- released.complete(())
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
           metrics.expectedGet(hit = true) -> 1,
         )
       } yield {}
@@ -803,7 +804,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual none[Int] }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedLoad(success = false) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
         )
       } yield {}
     }
@@ -820,7 +821,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual none[Int] }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedLoad(success = false) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
         )
       } yield {}
     }
@@ -841,7 +842,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedGet(hit = true) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
     }
@@ -868,7 +869,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedGet(hit = true) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
     }
@@ -887,7 +888,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual none }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedLoad(success = false) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
         )
       } yield {}
     }
@@ -906,7 +907,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { value shouldEqual none }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedLoad(success = false) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
         )
       } yield {}
     }
@@ -930,7 +931,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedLife -> 1,
           metrics.expectedClear -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
     }
@@ -957,7 +958,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedLife -> 1,
           metrics.expectedClear -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
     }
@@ -987,7 +988,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedLife -> 1,
           metrics.expectedClear -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
         )
       } yield {}
     }
@@ -1064,7 +1065,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
           metrics.expectedGet(hit = false) -> 1,
           metrics.expectedPut -> 3,
           metrics.expectedClear -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
           metrics.expectedValues -> 5,
           metrics.expectedLife -> 4,
         )
@@ -1082,7 +1083,10 @@ class CacheSpec extends AsyncFunSuite with Matchers {
             _ <- IO { result shouldEqual none }
             _ <- deferred.complete(0)
             _ <- fiber.joinWithNever
-            _ <- metrics.expect(metrics.expectedGet(hit = false) -> 2)
+            _ <- metrics.expect(
+              metrics.expectedGet(hit = false) -> 2,
+              metrics.expectedLoad(CacheMetrics.LoadResult.Cancelled) -> 1,
+            )
           } yield {}
         }
         .run()
@@ -1098,8 +1102,8 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { result shouldEqual 0.asRight }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedLoad(success = false) -> 1,
-          metrics.expectedLoad(success = true) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Failure) -> 1,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 1,
           metrics.expectedGet(hit = true) -> 1,
         )
       } yield {}
@@ -1147,7 +1151,7 @@ class CacheSpec extends AsyncFunSuite with Matchers {
         _ <- IO { a shouldEqual 6.pure[Outcome[IO, Throwable, *]] }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 3,
-          metrics.expectedLoad(success = true) -> 3,
+          metrics.expectedLoad(CacheMetrics.LoadResult.Success) -> 3,
           metrics.expectedFoldMap -> 1,
         )
       } yield {}
@@ -1509,7 +1513,7 @@ object CacheSpec {
     }
 
     def expectedGet(hit: Boolean): String = s"get(hit=$hit)"
-    def expectedLoad(success: Boolean): String = s"load(time=..., success=$success)"
+    def expectedLoad(result: CacheMetrics.LoadResult): String = s"load(time=..., result=$result)"
     val expectedLife: String = "life(time=...)"
     val expectedPut: String = "put"
     def expectedModify(entryExisted: Boolean, directive: CacheMetrics.Directive): String =
@@ -1522,7 +1526,7 @@ object CacheSpec {
     val expectedFoldMap: String = "foldMap(latency=...)"
 
     def get(hit: Boolean): IO[Unit] = inc(expectedGet(hit))
-    def load(time: FiniteDuration, success: Boolean): IO[Unit] = inc(expectedLoad(success))
+    def load(time: FiniteDuration, result: CacheMetrics.LoadResult): IO[Unit] = inc(expectedLoad(result))
     def life(time: FiniteDuration): IO[Unit] = inc(expectedLife)
     def put: IO[Unit] = inc(expectedPut)
     def modify(entryExisted: Boolean, directive: CacheMetrics.Directive): IO[Unit] =


### PR DESCRIPTION
Closes #386.

A load cancelled while running left no trace in `cache_load_result` and `cache_load_time`. `CacheMetered` now reports it with `result=cancelled` and the time spent until cancellation. `CacheMetrics.load` takes a `LoadResult` (success, failure, cancelled); the `Boolean` overload stays as a deprecated forwarder.