### PR TITLE
Fix flaky getOrUpdateOpt test

### DIFF
--- a/scache/src/test/scala/com/evolution/scache/CacheSpec.scala
+++ b/scache/src/test/scala/com/evolution/scache/CacheSpec.scala
@@ -438,17 +438,13 @@ class CacheSpec extends AsyncFunSuite with Matchers {
       for {
         deferred <- Deferred[IO, Option[Int]]
         value0 <- cache.getOrUpdateOptEnsure(0) { deferred.get }
-        value1 <- cache.getOrUpdateOpt(0)(0.some.pure[IO]).startEnsure
         _ <- deferred.complete(none)
         value0 <- value0.joinWithNever
-        value1 <- value1.joinWithNever
-        _ = value0 shouldEqual none[Int].asRight
-        _ = value1 shouldEqual none[Int]
+        _ <- IO { value0 shouldEqual none[Int].asRight }
         value <- cache.getOrUpdateOpt(0)(0.some.pure[IO])
-        _ = value shouldEqual 0.some
+        _ <- IO { value shouldEqual 0.some }
         _ <- metrics.expect(
           metrics.expectedGet(hit = false) -> 2,
-          metrics.expectedGet(hit = true) -> 1,
           metrics.expectedLoad(success = true) -> 2,
         )
       } yield {}


### PR DESCRIPTION
The second getOrUpdateOpt started via startEnsure could reach the cache after the first load already completed with None and removed the entry, so it did its own load and returned Some(0). Dropped the waiter, same shape as the getOrUpdateOpt1 test. Seen in https://github.com/evolution-gaming/scache/actions/runs/33754583586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded cache behavior coverage for sequential optional updates.
  * Verified initial empty results, value storage, and retention of an existing cached value.
  * Updated cache-hit metric expectations to match the revised scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->