### PR TITLE
Label pull requests by binary compatibility

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,1 +1,20 @@
 extends: scala-github-actions
+
+pull_request_rules:
+  - name: flag non breaking changes
+    conditions:
+      - check-success~=^test / binary-compatibility
+      - -check-pending~=^test / binary-compatibility
+      - -check-failure~=^test / binary-compatibility
+    actions:
+      label:
+        toggle:
+          - non-breaking-change
+
+  - name: flag binary incompatible changes
+    conditions:
+      - check-failure~=^test / binary-compatibility
+    actions:
+      label:
+        toggle:
+          - release-bump-needed


### PR DESCRIPTION
Trying the rules here before they go into the shared config. A pull request that keeps binary compatibility gets non-breaking-change, one that breaks it gets release-bump-needed, both driven off the test / binary-compatibility checks and cleared again by toggle.

Shared version is evolution-gaming/scala-github-actions#20, to be merged once this proves out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated pull request labels now reflect binary compatibility results.
  * Successful compatibility checks apply the `non-breaking-change` label.
  * Failed compatibility checks apply the `release-bump-needed` label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->